### PR TITLE
Adding wrapper for HttpClientHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ The `AddEventHandler()` method will subscribe to `BeforeRequestEvent`, `AfterRes
 
 ### Trace out-going HTTP requests (.NET and .NET Core) : [Nuget](https://www.nuget.org/packages/AWSXRayRecorder.Handlers.System.Net/)
 
+#### Using `System.Net.HttpWebRequest`
 #### Synchronous request
 
 An extension method `GetResponseTraced()` is provided to trace `GetResponse()` in `System.Net.HttpWebRequest` class. If you want to trace the out-going HTTP request, call the `GetResponseTraced()` instead of `GetResponse()`. The extension method will generate a trace subsegment, inject the trace header to the out-going HTTP request header and collect trace information. 
@@ -259,6 +260,21 @@ HttpWebRequest request = (HttpWebRequest) WebRequest.Create(URL); // enter desir
 // Any other configuration to the request
 
 request.GetAsyncResponseTraced();
+```
+
+#### Using `System.Net.HttpClient`
+
+A handler derived from `HttpClientHandler` is provided to trace `HttpClientHandler.SendAsync` method
+
+```
+using AWSXRayRecorder.Handlers.System.Net;
+
+var httpClient = new HttpClient(new HttpClientTracingHandler());
+
+// Any other configuration to the client
+
+httpClient.GetAsync(URL);
+
 ```
 
 ### Trace Query to SQL Server (.NET and .NET Core) : [Nuget](https://www.nuget.org/packages/AWSXRayRecorder.Handlers.SqlServer/)

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ request.GetAsyncResponseTraced();
 
 #### Using `System.Net.HttpClient`
 
-A handler derived from `HttpClientHandler` is provided to trace `HttpClientHandler.SendAsync` method
+A handler derived from `DelegatingHandler` is provided to trace the `HttpMessageHandler.SendAsync` method
 
 ```
 using AWSXRayRecorder.Handlers.System.Net;

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ A handler derived from `HttpClientHandler` is provided to trace `HttpClientHandl
 ```
 using AWSXRayRecorder.Handlers.System.Net;
 
-var httpClient = new HttpClient(new HttpClientTracingHandler());
+var httpClient = new HttpClient(new HttpClientTracingHandler(new HttpClientHandler()));
 
 // Any other configuration to the client
 

--- a/sdk/src/Handlers/System.Net/AWSXRayRecorder.Handlers.System.Net.csproj
+++ b/sdk/src/Handlers/System.Net/AWSXRayRecorder.Handlers.System.Net.csproj
@@ -37,4 +37,8 @@
     <ProjectReference Include="..\..\Core\AWSXRayRecorder.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
 </Project>

--- a/sdk/src/Handlers/System.Net/HttpClientTracingHandler.cs
+++ b/sdk/src/Handlers/System.Net/HttpClientTracingHandler.cs
@@ -1,0 +1,65 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="HttpClientTracingHandler.cs" company="Amazon.com">
+//      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+//      Licensed under the Apache License, Version 2.0 (the "License").
+//      You may not use this file except in compliance with the License.
+//      A copy of the License is located at
+//
+//      http://aws.amazon.com/apache2.0
+//
+//      or in the "license" file accompanying this file. This file is distributed
+//      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//      express or implied. See the License for the specific language governing
+//      permissions and limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.XRay.Recorder.Core;
+using Amazon.XRay.Recorder.Handlers.System.Net.Utils;
+
+namespace Amazon.XRay.Recorder.Handlers.System.Net
+{
+    /// <summary>
+    /// Wrapper around <see cref="HttpClientHandler"/> for AWS X-Ray tracing of HTTP requests
+    /// </summary>
+    public class HttpClientTracingHandler : HttpClientHandler
+    {
+
+        /// <summary>
+        /// Wrapper of <see cref="HttpClientHandler.SendAsync"/> method.
+        /// It collects information from request and response. Also, a trace header will be injected 
+        /// into the HttpWebRequest to propagate the tracing to downstream web service. 
+        /// </summary>
+        /// <param name="request">An instance of <see cref="HttpResponseMessage"/></param>
+        /// <param name="cancellationToken">An instance of <see cref="CancellationToken"/></param>
+        /// <returns>A Task of <see cref="HttpResponseMessage"/> representing the asynchronous operation</returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestUtil.ProcessRequest(request);
+            HttpResponseMessage response;
+            try
+            {
+                response = await base.SendAsync(request, cancellationToken);
+                RequestUtil.ProcessResponse(response);
+            }
+            catch (Exception ex)
+            {
+                AWSXRayRecorder.Instance.AddException(ex);
+                throw;
+            }
+            finally
+            {
+                AWSXRayRecorder.Instance.EndSubsegment();
+            }
+            return response;
+        }
+    }
+}

--- a/sdk/src/Handlers/System.Net/HttpClientTracingHandler.cs
+++ b/sdk/src/Handlers/System.Net/HttpClientTracingHandler.cs
@@ -30,8 +30,11 @@ namespace Amazon.XRay.Recorder.Handlers.System.Net
     /// <summary>
     /// Wrapper around <see cref="HttpClientHandler"/> for AWS X-Ray tracing of HTTP requests
     /// </summary>
-    public class HttpClientTracingHandler : HttpClientHandler
+    public class HttpClientTracingHandler : DelegatingHandler
     {
+        public HttpClientTracingHandler(HttpMessageHandler innerHandler) : base(innerHandler)
+        {
+        }
 
         /// <summary>
         /// Wrapper of <see cref="HttpClientHandler.SendAsync"/> method.

--- a/sdk/src/Handlers/System.Net/Utils/RequestUtil.cs
+++ b/sdk/src/Handlers/System.Net/Utils/RequestUtil.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon.XRay.Recorder.Core;
+using Amazon.XRay.Recorder.Core.Internal.Entities;
+using Amazon.XRay.Recorder.Core.Internal.Utils;
+
+namespace Amazon.XRay.Recorder.Handlers.System.Net.Utils
+{
+    public static class RequestUtil
+    {
+        /// <summary>
+        /// Collects information from and adds a tracing header to the request.
+        /// </summary>
+        /// <param name="request">An instance of <see cref="WebRequest"/></param>
+        internal static void ProcessRequest(WebRequest request)
+        {
+            ProcessRequest(request.RequestUri, request.Method, header => request.Headers.Add(TraceHeader.HeaderKey, header));
+        }
+        /// <summary>
+        /// Collects information from and adds a tracing header to the request.
+        /// </summary>
+        /// <param name="request">An instance of <see cref="HttpRequestMessage"/></param>
+        internal static void ProcessRequest(HttpRequestMessage request)
+        {
+            ProcessRequest(request.RequestUri, request.Method.Method, header => request.Headers.Add(TraceHeader.HeaderKey, header));
+        }
+
+        /// <summary>
+        /// Collects information from the response and adds to <see cref="AWSXRayRecorder"/> instance.
+        /// </summary>
+        /// <param name="request">An instance of <see cref="HttpWebResponse"/></param>
+        internal static void ProcessResponse(HttpWebResponse response)
+        {
+            ProcessResponse(response.StatusCode, response.ContentLength);
+        }
+
+        /// <summary>
+        /// Collects information from the response and adds to <see cref="AWSXRayRecorder"/> instance.
+        /// </summary>
+        /// <param name="request">An instance of <see cref="HttpResponseMessage"/></param>
+        internal static void ProcessResponse(HttpResponseMessage response)
+        {
+            ProcessResponse(response.StatusCode, response.Content.Headers.ContentLength);
+        }
+
+        private static void ProcessRequest(Uri uri, string method, Action<string> addHeaderAction)
+        {
+            if (!AWSXRayRecorder.Instance.IsTracingDisabled())
+            {
+                AWSXRayRecorder.Instance.BeginSubsegment(uri.Host);
+                AWSXRayRecorder.Instance.SetNamespace("remote");
+
+                var requestInformation = new Dictionary<string, object>
+                {
+                    ["url"] = uri.AbsoluteUri,
+                    ["method"] = method
+                };
+                AWSXRayRecorder.Instance.AddHttpInformation("request", requestInformation);
+            }
+
+            if (TraceHeader.TryParse(TraceContext.GetEntity(), out var header))
+            {
+                addHeaderAction(header.ToString());
+            }
+        }
+
+        private static void ProcessResponse(HttpStatusCode httpStatusCode, long? contentLength)
+        {
+            if (!AWSXRayRecorder.Instance.IsTracingDisabled())
+            {
+                var statusCode = (int)httpStatusCode;
+
+                var responseInformation = new Dictionary<string, object> { ["status"] = statusCode };
+                if (statusCode >= 400 && statusCode <= 499)
+                {
+                    AWSXRayRecorder.Instance.MarkError();
+
+                    if (statusCode == 429)
+                    {
+                        AWSXRayRecorder.Instance.MarkThrottle();
+                    }
+                }
+                else if (statusCode >= 500 && statusCode <= 599)
+                {
+                    AWSXRayRecorder.Instance.MarkFault();
+                }
+
+                responseInformation["content_length"] = contentLength;
+                AWSXRayRecorder.Instance.AddHttpInformation("response", responseInformation);
+            }
+        }
+
+    }
+}

--- a/sdk/test/UnitTests/HttpClientTracingHandlerTests.cs
+++ b/sdk/test/UnitTests/HttpClientTracingHandlerTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon.XRay.Recorder.Core;
+using Amazon.XRay.Recorder.Core.Internal.Entities;
+using Amazon.XRay.Recorder.Core.Internal.Utils;
+using Amazon.XRay.Recorder.Handlers.System.Net;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Amazon.XRay.Recorder.UnitTests
+{
+    [TestClass]
+    public class HttpClientTracingHandlerTests : TestBase
+    {
+        private const string URL = "https://httpbin.org/";
+
+        private const string URL404 = "https://httpbin.org/404";
+
+        private readonly HttpClient _httpClient;
+
+        public HttpClientTracingHandlerTests()
+        {
+            _httpClient = new HttpClient(new HttpClientTracingHandler());
+        }
+
+        [TestCleanup]
+        public new void TestCleanup()
+        {
+            base.TestCleanup();
+            AWSXRayRecorder.Instance.Dispose();
+            _httpClient.Dispose();
+        }
+
+        [TestMethod]
+        public async Task TestSendAsync()
+        {
+            AWSXRayRecorder.Instance.BeginSegment("parent", TraceId);
+            var request = new HttpRequestMessage(HttpMethod.Get, URL);
+            var response = await _httpClient.SendAsync(request);
+            
+            var segment = TraceContext.GetEntity();
+            AWSXRayRecorder.Instance.EndSegment();
+
+            var traceHeader = request.Headers.GetValues(TraceHeader.HeaderKey).FirstOrDefault();
+            Assert.IsNotNull(traceHeader);
+
+            var requestInfo = segment.Subsegments[0].Http["request"] as Dictionary<string, object>;
+            Assert.AreEqual(URL, requestInfo["url"]);
+            Assert.AreEqual("GET", requestInfo["method"]);
+
+            var responseInfo = segment.Subsegments[0].Http["response"] as Dictionary<string, object>;
+            Assert.AreEqual(200, responseInfo["status"]);
+            Assert.AreEqual(13011L, responseInfo["content_length"]);
+        }
+
+        [TestMethod]
+        public async Task Test404SendAsync()
+        {
+            AWSXRayRecorder.Instance.BeginSegment("parent", TraceId);
+            var request = new HttpRequestMessage(HttpMethod.Get, URL404);
+            var response = await _httpClient.SendAsync(request);
+            
+            var segment = TraceContext.GetEntity();
+            AWSXRayRecorder.Instance.EndSegment();
+
+            var traceHeader = request.Headers.GetValues(TraceHeader.HeaderKey).FirstOrDefault();
+            Assert.IsNotNull(traceHeader);
+
+            var requestInfo = segment.Subsegments[0].Http["request"] as Dictionary<string, object>;
+            Assert.AreEqual(URL404, requestInfo["url"]);
+            Assert.AreEqual("GET", requestInfo["method"]);
+
+            var responseInfo = segment.Subsegments[0].Http["response"] as Dictionary<string, object>;
+            Assert.AreEqual(404, responseInfo["status"]);
+        }
+    }
+}

--- a/sdk/test/UnitTests/HttpClientTracingHandlerTests.cs
+++ b/sdk/test/UnitTests/HttpClientTracingHandlerTests.cs
@@ -24,9 +24,9 @@ namespace Amazon.XRay.Recorder.UnitTests
 
         public HttpClientTracingHandlerTests()
         {
-            _httpClient = new HttpClient(new HttpClientTracingHandler());
+            _httpClient = new HttpClient(new HttpClientTracingHandler(new HttpClientHandler()));
         }
-
+        
         [TestCleanup]
         public new void TestCleanup()
         {


### PR DESCRIPTION
This is referring to feature request #4 

This provides tracing capabilities to `HttpClient` by passing in a custom `HttpClientHandler`. As part of this I pulled out the actual request/response processing into a utility class `RequestUtil`.

I placed this wrapper in project `Amazon.XRay.Recorder.Handlers.System.Net` although HttpClient is actually in the System.Net.Http namespace. I think it makes sense for it to live in the same project as `HttpWebRequestTracingExtension`, but please let me know if I should change the namespace to `Amazon.XRay.Recorder.Handlers.System.Net.Http`