### PR TITLE
Adding support for context missing option from IConfiguration

### DIFF
--- a/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
+++ b/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
@@ -84,7 +84,7 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
         public bool IsXRayTracingDisabled { get => _isXRayTracingDisabled; set => _isXRayTracingDisabled = value; }
 
         /// <summary>
-        /// Determines whether runtime errors should occur when recording of data is attempted and a tracing header is not available, either true or false.
+        /// For missing Segments/Subsegments, if set to true, runtime exception is thrown, if set to false, runtime exceptions are avoided and logged.
         /// </summary>
         public bool UseRuntimeErrors { get => _useRuntimeErrors; set => _useRuntimeErrors = value; }
     }

--- a/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
+++ b/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
@@ -21,10 +21,11 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
     /// </summary>
     public class XRayOptions
     {
-        private  string _pluginSetting;
-        private  string _samplingRuleManifest;
-        private  string _awsServiceHandlerManifest;
-        private  bool _isXRayTracingDisabled ;
+        private string _pluginSetting;
+        private string _samplingRuleManifest;
+        private string _awsServiceHandlerManifest;
+        private bool _isXRayTracingDisabled;
+        private bool _useRuntimeErrors;
 
         /// <summary>
         /// Default constructor.
@@ -40,12 +41,26 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
         /// <param name="samplingRuleManifest">Sampling rule file path</param>
         /// <param name="awsServiceHandlerManifest">AWS Service manifest file path.</param>
         /// <param name="isXRayTracingDisabled">Tracing disabled value, either true or false.</param>
-        public XRayOptions(string pluginSetting, string samplingRuleManifest, string awsServiceHandlerManifest, bool isXRayTracingDisabled)
+        public XRayOptions(string pluginSetting, string samplingRuleManifest, string awsServiceHandlerManifest,
+            bool isXRayTracingDisabled) : this(pluginSetting, samplingRuleManifest, awsServiceHandlerManifest, isXRayTracingDisabled, true)
+        {
+        }
+
+        /// <summary>
+        /// Creates instance of <see cref="XRayOptions"/>
+        /// </summary>
+        /// <param name="pluginSetting">Plugin setting.</param>
+        /// <param name="samplingRuleManifest">Sampling rule file path</param>
+        /// <param name="awsServiceHandlerManifest">AWS Service manifest file path.</param>
+        /// <param name="isXRayTracingDisabled">Tracing disabled value, either true or false.</param>
+        /// <param name="useRuntimeErrors">Should errors be thrown at runtime if segment not started, either true or false.</param>
+        public XRayOptions(string pluginSetting, string samplingRuleManifest, string awsServiceHandlerManifest, bool isXRayTracingDisabled, bool useRuntimeErrors)
         {
             PluginSetting = pluginSetting;
             SamplingRuleManifest = samplingRuleManifest;
             AwsServiceHandlerManifest = awsServiceHandlerManifest;
             IsXRayTracingDisabled = isXRayTracingDisabled;
+            UseRuntimeErrors = useRuntimeErrors;
         }
 
         /// <summary>
@@ -67,5 +82,10 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
         /// Tracing disabled value, either true or false.
         /// </summary>
         public bool IsXRayTracingDisabled { get => _isXRayTracingDisabled; set => _isXRayTracingDisabled = value; }
+
+        /// <summary>
+        /// Determines whether runtime errors should occur when recording of data is attempted and a tracing header is not available, either true or false.
+        /// </summary>
+        public bool UseRuntimeErrors { get => _useRuntimeErrors; set => _useRuntimeErrors = value; }
     }
 }

--- a/sdk/src/Core/Internal/Utils/ConfigurationExtensions.cs
+++ b/sdk/src/Core/Internal/Utils/ConfigurationExtensions.cs
@@ -30,6 +30,7 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
         private const string SamplingRuleManifestKey = "SamplingRuleManifest";
         private const string AWSServiceHandlerManifestKey = "AWSServiceHandlerManifest";
         private const string DisableXRayTracingKey = "DisableXRayTracing";
+        private const string UseRuntimeErrorsKey = "UseRuntimeErrors";
 
         /// <summary>
         /// Reads configuration from <see cref="IConfiguration"/> object for X-Ray.
@@ -61,6 +62,7 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
             options.SamplingRuleManifest = GetSetting(SamplingRuleManifestKey, section);
             options.AwsServiceHandlerManifest =GetSetting(AWSServiceHandlerManifestKey, section);
             options.IsXRayTracingDisabled = GetSettingBool(DisableXRayTracingKey,section);
+            options.UseRuntimeErrors = GetSettingBool(UseRuntimeErrorsKey, section, defaultValue: true);
             return options;
         }
 

--- a/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
+++ b/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
@@ -101,6 +101,12 @@
     <None Update="JSONs\Appsetting\DisabledXRayTrue.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="JSONs\Appsetting\UseRuntimeErrorsFalse.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="JSONs\Appsetting\UseRuntimeErrorsTrue.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="JSONs\AWSRequestInfo.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/sdk/test/UnitTests/JSONs/Appsetting/UseRuntimeErrorsFalse.json
+++ b/sdk/test/UnitTests/JSONs/Appsetting/UseRuntimeErrorsFalse.json
@@ -1,0 +1,5 @@
+﻿{
+  "XRay": {
+    "UseRuntimeErrors": "false"
+  }
+}

--- a/sdk/test/UnitTests/JSONs/Appsetting/UseRuntimeErrorsTrue.json
+++ b/sdk/test/UnitTests/JSONs/Appsetting/UseRuntimeErrorsTrue.json
@@ -1,0 +1,5 @@
+﻿{
+  "XRay": {
+    "UseRuntimeErrors": "true"
+  }
+}

--- a/sdk/test/UnitTests/TestXRayOptions.cs
+++ b/sdk/test/UnitTests/TestXRayOptions.cs
@@ -126,6 +126,8 @@ namespace Amazon.XRay.Recorder.UnitTests
             Assert.IsNull(_xRayOptions.AwsServiceHandlerManifest);
             Assert.IsNull(_xRayOptions.PluginSetting);
             Assert.IsNull(_xRayOptions.SamplingRuleManifest);
+            Assert.IsTrue(_xRayOptions.UseRuntimeErrors);
+
             Assert.AreEqual(typeof(UdpSegmentEmitter), AWSXRayRecorder.Instance.Emitter.GetType()); // Default emitter set
 
             AWSXRayRecorder.Instance.Dispose();
@@ -144,6 +146,7 @@ namespace Amazon.XRay.Recorder.UnitTests
             Assert.IsNull(_xRayOptions.AwsServiceHandlerManifest);
             Assert.IsNull(_xRayOptions.PluginSetting);
             Assert.IsNull(_xRayOptions.SamplingRuleManifest);
+            Assert.IsTrue(_xRayOptions.UseRuntimeErrors);
 
             Assert.AreEqual(AWSXRayRecorder.Instance.SamplingStrategy, recorder.SamplingStrategy); // Custom recorder set in TraceContext
             Assert.AreEqual(typeof(UdpSegmentEmitter), recorder.Emitter.GetType()); // Default emitter set
@@ -163,10 +166,38 @@ namespace Amazon.XRay.Recorder.UnitTests
             Assert.IsNull(_xRayOptions.AwsServiceHandlerManifest);
             Assert.IsNull(_xRayOptions.PluginSetting);
             Assert.IsNull(_xRayOptions.SamplingRuleManifest);
+            Assert.IsTrue(_xRayOptions.UseRuntimeErrors);
 
             Assert.AreEqual(AWSXRayRecorder.Instance.SamplingStrategy, recorder.SamplingStrategy); // Custom recorder set in TraceContext
             Assert.AreEqual(typeof(DummyEmitter), recorder.Emitter.GetType()); // custom emitter set
             recorder.Dispose();
+        }
+        
+        [TestMethod]
+        public void TestUseRuntimeErrorsFalse()
+        {
+            IConfiguration configuration = BuildConfiguration("UseRuntimeErrorsFalse.json");
+
+            _xRayOptions = XRayConfiguration.GetXRayOptions(configuration);
+            Assert.IsFalse(_xRayOptions.UseRuntimeErrors);
+        }
+
+        [TestMethod]
+        public void TestUseRuntimeErrorsTrue()
+        {
+            IConfiguration configuration = BuildConfiguration("UseRuntimeErrorsTrue.json");
+
+            _xRayOptions = XRayConfiguration.GetXRayOptions(configuration);
+            Assert.IsTrue(_xRayOptions.UseRuntimeErrors);
+        }
+
+        [TestMethod]
+        public void TestUseRuntimeErrorsDefaultsTrue_WhenNotSpecifiedInJson()
+        {
+            IConfiguration configuration = BuildConfiguration("DisabledXRayMissing.json");
+
+            _xRayOptions = XRayConfiguration.GetXRayOptions(configuration);
+            Assert.IsTrue(_xRayOptions.UseRuntimeErrors);
         }
 
         // Creating custom configuration


### PR DESCRIPTION
Fixes #33 

Adds support for setting a UseRuntimeErrors option via .NET Core IConfiguration. When available the value from configuration will be applied. Otherwise, this defaults to true to ensure existing behaviour is respected.

If set, the value from AWS_XRAY_CONTEXT_MISSING will override the value from IConfiguration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.