### PR TITLE
Prevent X-Amzn-Trace-Id from Being Added More Than Once

### DIFF
--- a/sdk/src/Handlers/System.Net/Utils/RequestUtil.cs
+++ b/sdk/src/Handlers/System.Net/Utils/RequestUtil.cs
@@ -24,15 +24,12 @@ namespace Amazon.XRay.Recorder.Handlers.System.Net.Utils
         /// <param name="request">An instance of <see cref="HttpRequestMessage"/></param>
         internal static void ProcessRequest(HttpRequestMessage request)
         {
-            ProcessRequest(request.RequestUri, request.Method.Method, AddHeader);
+            ProcessRequest(request.RequestUri, request.Method.Method, AddOrReplaceHeader);
 
-            void AddHeader(string header)
+            void AddOrReplaceHeader(string header)
             {
-                // If we've already added a trace header, don't add another one.
-                if (!request.Headers.Contains(TraceHeader.HeaderKey))
-                {
-                    request.Headers.Add(TraceHeader.HeaderKey, header);
-                }
+                request.Headers.Remove(TraceHeader.HeaderKey);
+                request.Headers.Add(TraceHeader.HeaderKey, header);
             }
         }
 

--- a/sdk/src/Handlers/System.Net/Utils/RequestUtil.cs
+++ b/sdk/src/Handlers/System.Net/Utils/RequestUtil.cs
@@ -24,7 +24,16 @@ namespace Amazon.XRay.Recorder.Handlers.System.Net.Utils
         /// <param name="request">An instance of <see cref="HttpRequestMessage"/></param>
         internal static void ProcessRequest(HttpRequestMessage request)
         {
-            ProcessRequest(request.RequestUri, request.Method.Method, header => request.Headers.Add(TraceHeader.HeaderKey, header));
+            ProcessRequest(request.RequestUri, request.Method.Method, AddHeader);
+
+            void AddHeader(string header)
+            {
+                // If we've already added a trace header, don't add another one.
+                if (!request.Headers.Contains(TraceHeader.HeaderKey))
+                {
+                    request.Headers.Add(TraceHeader.HeaderKey, header);
+                }
+            }
         }
 
         /// <summary>

--- a/sdk/test/UnitTests/HttpClientXRayTracingHandlerTests.cs
+++ b/sdk/test/UnitTests/HttpClientXRayTracingHandlerTests.cs
@@ -55,7 +55,7 @@ namespace Amazon.XRay.Recorder.UnitTests
             var segment = TraceContext.GetEntity();
             AWSXRayRecorder.Instance.EndSegment();
 
-            var traceHeader = request.Headers.GetValues(TraceHeader.HeaderKey).FirstOrDefault();
+            var traceHeader = request.Headers.GetValues(TraceHeader.HeaderKey).SingleOrDefault();
             Assert.IsNotNull(traceHeader);
 
             var requestInfo = segment.Subsegments[0].Http["request"] as Dictionary<string, object>;
@@ -77,7 +77,7 @@ namespace Amazon.XRay.Recorder.UnitTests
             var segment = TraceContext.GetEntity();
             AWSXRayRecorder.Instance.EndSegment();
 
-            var traceHeader = request.Headers.GetValues(TraceHeader.HeaderKey).FirstOrDefault();
+            var traceHeader = request.Headers.GetValues(TraceHeader.HeaderKey).SingleOrDefault();
             Assert.IsNotNull(traceHeader);
 
             var requestInfo = segment.Subsegments[0].Http["request"] as Dictionary<string, object>;


### PR DESCRIPTION
Under some circumstances, the chain of calls through
`DelegatingHandler` instances can reach a particular handler more than
once. When that handler is `HttpClientXRayTracingHandler`, it produces
an X-Amzn-Trace-Id header that cannot be parsed because it is
_multiple_ headers. (As represented in a string by separating them
with ", ".)

This patch checks whether X-Amzn-Trace-Id has already been added, and
skips adding another if it already has been.

*Issue #, if available:*

N/A

*Description of changes:*

Adds X-Amzn-Trace-Id at most once.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
