### PR TITLE
add missing intercept to ExecuteDbDataReader

### DIFF
--- a/sdk/src/Handlers/SqlServer/TraceableSqlCommand.netstandard.cs
+++ b/sdk/src/Handlers/SqlServer/TraceableSqlCommand.netstandard.cs
@@ -391,7 +391,7 @@ namespace Amazon.XRay.Recorder.Handlers.SqlServer
         /// </returns>
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
         {
-            return InnerSqlCommand.ExecuteReader(behavior);
+            return Intercept(() => InnerSqlCommand.ExecuteReader(behavior));
         }
 
         private async Task<TResult> InterceptAsync<TResult>(Func<Task<TResult>> method)


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

There is a missing intercept for `ExecuteDbDataReader` on `TraceableSqlCommand`. There aren't any tests on this file yet, which is why I haven't added any.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
