### PR TITLE
Add command text to SQL command

### DIFF
--- a/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
+++ b/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
@@ -21,12 +21,6 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
     /// </summary>
     public class XRayOptions
     {
-        private string _pluginSetting;
-        private string _samplingRuleManifest;
-        private string _awsServiceHandlerManifest;
-        private bool _isXRayTracingDisabled;
-        private bool _useRuntimeErrors = true;
-
         /// <summary>
         /// Default constructor.
         /// </summary>
@@ -54,38 +48,47 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
         /// <param name="awsServiceHandlerManifest">AWS Service manifest file path.</param>
         /// <param name="isXRayTracingDisabled">Tracing disabled value, either true or false.</param>
         /// <param name="useRuntimeErrors">Should errors be thrown at runtime if segment not started, either true or false.</param>
-        public XRayOptions(string pluginSetting, string samplingRuleManifest, string awsServiceHandlerManifest, bool isXRayTracingDisabled, bool useRuntimeErrors)
+        public XRayOptions(string pluginSetting, string samplingRuleManifest, string awsServiceHandlerManifest, bool isXRayTracingDisabled, bool useRuntimeErrors, bool collectSqlQueries = false)
         {
             PluginSetting = pluginSetting;
             SamplingRuleManifest = samplingRuleManifest;
             AwsServiceHandlerManifest = awsServiceHandlerManifest;
             IsXRayTracingDisabled = isXRayTracingDisabled;
             UseRuntimeErrors = useRuntimeErrors;
+            CollectSqlQueries = collectSqlQueries;
         }
 
         /// <summary>
         /// Plugin setting.
         /// </summary>
-        public string PluginSetting { get => _pluginSetting; set => _pluginSetting = value; }
+        public string PluginSetting { get; set; }
 
         /// <summary>
         /// Sampling rule file path.
         /// </summary>
-        public string SamplingRuleManifest { get => _samplingRuleManifest; set => _samplingRuleManifest = value; }
+        public string SamplingRuleManifest { get; set; }
 
         /// <summary>
         /// AWS Service manifest file path.
         /// </summary>
-        public string AwsServiceHandlerManifest { get => _awsServiceHandlerManifest; set => _awsServiceHandlerManifest = value; }
+        public string AwsServiceHandlerManifest { get; set; }
 
         /// <summary>
         /// Tracing disabled value, either true or false.
         /// </summary>
-        public bool IsXRayTracingDisabled { get => _isXRayTracingDisabled; set => _isXRayTracingDisabled = value; }
+        public bool IsXRayTracingDisabled { get; set; }
 
         /// <summary>
         /// For missing Segments/Subsegments, if set to true, runtime exception is thrown, if set to false, runtime exceptions are avoided and logged.
         /// </summary>
-        public bool UseRuntimeErrors { get => _useRuntimeErrors; set => _useRuntimeErrors = value; }
+        public bool UseRuntimeErrors { get; set; } = true;
+
+        /// <summary>
+        /// Include the <see cref="TraceableSqlCommand.CommandText" /> in the sanitized_query.
+        /// Parameterized values will appear in their tokenized form and will not be expanded.
+        /// You should not enable this flag if you are not including sensitive information as clear text.
+        /// This flag can also be overridden for each <see cref="TraceableSqlCommand" /> instance individually.
+        /// </summary>
+        public bool CollectSqlQueries { get; set; }
     }
 }

--- a/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
+++ b/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
@@ -49,10 +49,10 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
         /// <param name="isXRayTracingDisabled">Tracing disabled value, either true or false.</param>
         /// <param name="useRuntimeErrors">Should errors be thrown at runtime if segment not started, either true or false.</param>
         /// <param name="collectSqlQueries">
-        /// Include the <see cref="TraceableSqlCommand.CommandText" /> in the sanitized_query section of 
+        /// Include the TraceableSqlCommand.CommandText in the sanitized_query section of 
         /// the SQL subsegment. Parameterized values will appear in their tokenized form and will not be expanded.
         /// You should not enable this flag if you are including sensitive information as clear text.
-        /// This flag can also be overridden for each <see cref="TraceableSqlCommand" /> instance individually.
+        /// This flag can also be overridden for each TraceableSqlCommand instance individually.
         /// See the official documentation on <a href="https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.parameters?view=netframework-4.7.2">SqlCommand.Parameters</a>
         /// </param>
         public XRayOptions(string pluginSetting, string samplingRuleManifest, string awsServiceHandlerManifest, bool isXRayTracingDisabled, bool useRuntimeErrors, bool collectSqlQueries = false)

--- a/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
+++ b/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
@@ -48,6 +48,13 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
         /// <param name="awsServiceHandlerManifest">AWS Service manifest file path.</param>
         /// <param name="isXRayTracingDisabled">Tracing disabled value, either true or false.</param>
         /// <param name="useRuntimeErrors">Should errors be thrown at runtime if segment not started, either true or false.</param>
+        /// <param name="collectSqlQueries">
+        /// Include the <see cref="TraceableSqlCommand.CommandText" /> in the sanitized_query section of 
+        /// the SQL subsegment. Parameterized values will appear in their tokenized form and will not be expanded.
+        /// You should not enable this flag if you are including sensitive information as clear text.
+        /// This flag can also be overridden for each <see cref="TraceableSqlCommand" /> instance individually.
+        /// See the official documentation on <a href="https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.parameters?view=netframework-4.7.2">SqlCommand.Parameters</a>
+        /// </param>
         public XRayOptions(string pluginSetting, string samplingRuleManifest, string awsServiceHandlerManifest, bool isXRayTracingDisabled, bool useRuntimeErrors, bool collectSqlQueries = false)
         {
             PluginSetting = pluginSetting;
@@ -84,10 +91,11 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
         public bool UseRuntimeErrors { get; set; } = true;
 
         /// <summary>
-        /// Include the <see cref="TraceableSqlCommand.CommandText" /> in the sanitized_query.
-        /// Parameterized values will appear in their tokenized form and will not be expanded.
+        /// Include the <see cref="TraceableSqlCommand.CommandText" /> in the sanitized_query section of 
+        /// the SQL subsegment. Parameterized values will appear in their tokenized form and will not be expanded.
         /// You should not enable this flag if you are not including sensitive information as clear text.
-        /// This flag can also be overridden for each <see cref="TraceableSqlCommand" /> instance individually.
+        /// When set to true, the sanitized sql query will be recorded for all the instances of TraceableSqlCommand
+        /// in the application, unless it is overridden on the individual <see cref="TraceableSqlCommand" /> instances.
         /// </summary>
         public bool CollectSqlQueries { get; set; }
     }

--- a/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
+++ b/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
@@ -97,6 +97,6 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
         /// When set to true, the sanitized sql query will be recorded for all the instances of TraceableSqlCommand
         /// in the application, unless it is overridden on the individual <see cref="TraceableSqlCommand" /> instances.
         /// </summary>
-        public bool CollectSqlQueries { get; set; }
+        public bool CollectSqlQueries { get; set; } = false;
     }
 }

--- a/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
+++ b/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
@@ -91,11 +91,11 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
         public bool UseRuntimeErrors { get; set; } = true;
 
         /// <summary>
-        /// Include the <see cref="TraceableSqlCommand.CommandText" /> in the sanitized_query section of 
+        /// Include the TraceableSqlCommand.CommandText in the sanitized_query section of 
         /// the SQL subsegment. Parameterized values will appear in their tokenized form and will not be expanded.
         /// You should not enable this flag if you are not including sensitive information as clear text.
         /// When set to true, the sanitized sql query will be recorded for all the instances of TraceableSqlCommand
-        /// in the application, unless it is overridden on the individual <see cref="TraceableSqlCommand" /> instances.
+        /// in the application, unless it is overridden on the individual TraceableSqlCommand instances.
         /// </summary>
         public bool CollectSqlQueries { get; set; } = false;
     }

--- a/sdk/src/Core/Internal/Utils/ConfigurationExtensions.cs
+++ b/sdk/src/Core/Internal/Utils/ConfigurationExtensions.cs
@@ -31,6 +31,7 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
         private const string AWSServiceHandlerManifestKey = "AWSServiceHandlerManifest";
         private const string DisableXRayTracingKey = "DisableXRayTracing";
         private const string UseRuntimeErrorsKey = "UseRuntimeErrors";
+        private const string CollectSqlQueries = "CollectSqlQueries";
 
         /// <summary>
         /// Reads configuration from <see cref="IConfiguration"/> object for X-Ray.
@@ -63,6 +64,7 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
             options.AwsServiceHandlerManifest =GetSetting(AWSServiceHandlerManifestKey, section);
             options.IsXRayTracingDisabled = GetSettingBool(DisableXRayTracingKey,section);
             options.UseRuntimeErrors = GetSettingBool(UseRuntimeErrorsKey, section, defaultValue: true);
+            options.CollectSqlQueries = GetSettingBool(CollectSqlQueries, section, defaultValue: false);
             return options;
         }
 

--- a/sdk/src/Core/Properties/AssemblyInfo.cs
+++ b/sdk/src/Core/Properties/AssemblyInfo.cs
@@ -1,5 +1,13 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(true)]
+[assembly: InternalsVisibleTo("AWSXRayRecorder.UnitTests,PublicKey="+
+"0024000004800000940000000602000000240000525341310004000001000100712913451f6deb"
++ "158da1d2129b21119cca7d4eebeef5b310e8acd7f2d9506346071207652f1210a3bfa1545d6897"
++ "a607fc3a515954e660ec6fc5797730022867514e58411e8ecd61c767a319d2c29facee20f5d4f4"
++ "2b5425f27518616a8f4c1e5ac0e3e2b407bd8786d1b360af6b49c2b987478fe76b124c72f48864"
++ "55199df6"
+)]

--- a/sdk/src/Handlers/SqlServer/DbCommandInterceptor.cs
+++ b/sdk/src/Handlers/SqlServer/DbCommandInterceptor.cs
@@ -136,6 +136,11 @@ namespace Amazon.XRay.Recorder.Handlers.SqlServer
             }
         }
 
+        /// <summary>
+        /// Builds the name of the subsegment in the format database@datasource
+        /// </summary>
+        /// <param name="command"></param>
+        /// <returns>Returns the formed subsegment name as a string.</returns>
         private string BuildSubsegmentName(DbCommand command) 
             => command.Connection.Database + "@" + SqlUtil.RemovePortNumberFromDataSource(command.Connection.DataSource);
 

--- a/sdk/src/Handlers/SqlServer/DbCommandInterceptor.cs
+++ b/sdk/src/Handlers/SqlServer/DbCommandInterceptor.cs
@@ -139,7 +139,12 @@ namespace Amazon.XRay.Recorder.Handlers.SqlServer
         private string BuildSubsegmentName(DbCommand command) 
             => command.Connection.Database + "@" + SqlUtil.RemovePortNumberFromDataSource(command.Connection.DataSource);
 
+#if !NET45
         private bool ShouldCollectSqlText() 
             => _collectSqlQueriesOverride ?? _recorder.XRayOptions.CollectSqlQueries;
+#else
+        private bool ShouldCollectSqlText()
+            => _collectSqlQueriesOverride ?? false;
+#endif
     }
 }

--- a/sdk/src/Handlers/SqlServer/DbCommandInterceptor.cs
+++ b/sdk/src/Handlers/SqlServer/DbCommandInterceptor.cs
@@ -1,0 +1,117 @@
+//-----------------------------------------------------------------------------
+// <copyright file="DbCommandInterceptor.cs" company="Amazon.com">
+//      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+//      Licensed under the Apache License, Version 2.0 (the "License").
+//      You may not use this file except in compliance with the License.
+//      A copy of the License is located at
+//
+//      http://aws.amazon.com/apache2.0
+//
+//      or in the "license" file accompanying this file. This file is distributed
+//      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//      express or implied. See the License for the specific language governing
+//      permissions and limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using Amazon.XRay.Recorder.Core;
+
+namespace Amazon.XRay.Recorder.Handlers.SqlServer
+{
+    public interface IDbCommandInterceptor
+    {
+        Task<TResult> InterceptAsync<TResult>(Func<Task<TResult>> method, DbCommand command);
+        TResult Intercept<TResult>(Func<TResult> method, DbCommand command);
+    }
+
+    public class DbCommandInterceptor : IDbCommandInterceptor
+    {
+        private const string DataBaseTypeString = "sqlserver";
+        private readonly AWSXRayRecorder _recorder;
+        private readonly bool? _collectSqlQueriesOverride;        
+
+        public DbCommandInterceptor(AWSXRayRecorder recorder, bool? collectSqlQueries = null)
+        {
+            _recorder = recorder;
+            _collectSqlQueriesOverride = collectSqlQueries;
+        }
+
+        public async Task<TResult> InterceptAsync<TResult>(Func<Task<TResult>> method, DbCommand command)
+        {
+            _recorder.BeginSubsegment(BuildSegmentName(command));
+            try
+            {
+                _recorder.SetNamespace("remote");
+                var ret = await method();
+                CollectSqlInformation(command);
+
+                return ret;
+            }
+            catch (Exception e)
+            {
+                _recorder.AddException(e);
+                throw;
+            }
+            finally
+            {
+                _recorder.EndSubsegment();
+            }
+        }
+
+        public TResult Intercept<TResult>(Func<TResult> method, DbCommand command)
+        {
+            _recorder.BeginSubsegment(BuildSegmentName(command));
+            try
+            {
+                _recorder.SetNamespace("remote");
+                var ret = method();
+                CollectSqlInformation(command);
+
+                return ret;
+            }
+            catch (Exception e)
+            {
+                _recorder.AddException(e);
+                throw;
+            }
+            finally
+            {
+                _recorder.EndSubsegment();
+            }
+        }
+
+        protected virtual void CollectSqlInformation(DbCommand command)
+        {
+            _recorder.AddSqlInformation("database_type", DataBaseTypeString);
+
+            _recorder.AddSqlInformation("database_version", command.Connection.ServerVersion);
+
+            SqlConnectionStringBuilder connectionStringBuilder = new SqlConnectionStringBuilder(command.Connection.ConnectionString);
+
+            // Remove sensitive information from connection string
+            connectionStringBuilder.Remove("Password");
+
+            _recorder.AddSqlInformation("user", connectionStringBuilder.UserID);
+            _recorder.AddSqlInformation("connection_string", connectionStringBuilder.ToString());
+
+            if(ShouldCollectSqlText()) 
+            {
+                _recorder.AddSqlInformation("sanitized_query", command.CommandText);
+            }
+        }
+
+        private string BuildSegmentName(DbCommand command) 
+            => command.Connection.Database + "@" + SqlUtil.RemovePortNumberFromDataSource(command.Connection.DataSource);
+
+        private bool ShouldCollectSqlText() 
+            => _collectSqlQueriesOverride ?? _recorder.XRayOptions.CollectSqlQueries;
+    }
+}

--- a/sdk/src/Handlers/SqlServer/TraceableSqlCommand.netstandard.cs
+++ b/sdk/src/Handlers/SqlServer/TraceableSqlCommand.netstandard.cs
@@ -39,11 +39,12 @@ namespace Amazon.XRay.Recorder.Handlers.SqlServer
         /// Initializes a new instance of the <see cref="TraceableSqlCommand"/> class.
         /// </summary>
         /// <param name="collectSqlQueries">
-        /// Include the <see cref="TraceableSqlCommand.CommandText" /> in the sanitized_query.
-        /// Parameterized values will appear in their tokenized form and will not be expanded.
+        /// Include the <see cref="TraceableSqlCommand.CommandText" /> in the sanitized_query section of 
+        /// the SQL subsegment. Parameterized values will appear in their tokenized form and will not be expanded.
         /// You should not enable this flag if you are not including sensitive information as clear text.
         /// This flag will overridde any behavior configured by <see cref="XRayOptions.CollectSqlQueries" />.
-        /// If a value is not provided, then the globally configured value will be used, which is fals by default.
+        /// If a value is not provided, then the globally configured value will be used, which is false by default.
+        /// See the official documentation on <a href="https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.parameters?view=netframework-4.7.2">SqlCommand.Parameters</a>
         /// </param>
         public TraceableSqlCommand(bool? collectSqlQueries = null)
         {
@@ -56,11 +57,12 @@ namespace Amazon.XRay.Recorder.Handlers.SqlServer
         /// </summary>
         /// <param name="cmdText">The text of the query.</param>
         /// <param name="collectSqlQueries">
-        /// Include the <see cref="TraceableSqlCommand.CommandText" /> in the sanitized_query.
-        /// Parameterized values will appear in their tokenized form and will not be expanded.
+        /// Include the <see cref="TraceableSqlCommand.CommandText" /> in the sanitized_query section of 
+        /// the SQL subsegment. Parameterized values will appear in their tokenized form and will not be expanded.
         /// You should not enable this flag if you are not including sensitive information as clear text.
         /// This flag will overridde any behavior configured by <see cref="XRayOptions.CollectSqlQueries" />.
-        /// If a value is not provided, then the globally configured value will be used, which is fals by default.
+        /// If a value is not provided, then the globally configured value will be used, which is false by default.
+        /// See the official documentation on <a href="https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.parameters?view=netframework-4.7.2">SqlCommand.Parameters</a>
         /// </param>
         public TraceableSqlCommand(string cmdText, bool? collectSqlQueries = null)
         {
@@ -74,11 +76,12 @@ namespace Amazon.XRay.Recorder.Handlers.SqlServer
         /// <param name="cmdText">The text of the query.</param>
         /// <param name="connection">The connection to an instance of SQL Server.</param>
         /// <param name="collectSqlQueries">
-        /// Include the <see cref="TraceableSqlCommand.CommandText" /> in the sanitized_query.
-        /// Parameterized values will appear in their tokenized form and will not be expanded.
+        /// Include the <see cref="TraceableSqlCommand.CommandText" /> in the sanitized_query section of 
+        /// the SQL subsegment. Parameterized values will appear in their tokenized form and will not be expanded.
         /// You should not enable this flag if you are not including sensitive information as clear text.
         /// This flag will overridde any behavior configured by <see cref="XRayOptions.CollectSqlQueries" />.
-        /// If a value is not provided, then the globally configured value will be used, which is fals by default.
+        /// If a value is not provided, then the globally configured value will be used, which is false by default.
+        /// See the official documentation on <a href="https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.parameters?view=netframework-4.7.2">SqlCommand.Parameters</a>
         /// </param>
         public TraceableSqlCommand(string cmdText, SqlConnection connection, bool? collectSqlQueries = null)
         {
@@ -93,11 +96,12 @@ namespace Amazon.XRay.Recorder.Handlers.SqlServer
         /// <param name="connection">The connection to an instance of SQL Server.</param>
         /// <param name="transaction">The <see cref="SqlTransaction"/> in which the <see cref="SqlCommand"/> executes.</param>
         /// <param name="collectSqlQueries">
-        /// Include the <see cref="TraceableSqlCommand.CommandText" /> in the sanitized_query.
-        /// Parameterized values will appear in their tokenized form and will not be expanded.
+        /// Include the <see cref="TraceableSqlCommand.CommandText" /> in the sanitized_query section of 
+        /// the SQL subsegment. Parameterized values will appear in their tokenized form and will not be expanded.
         /// You should not enable this flag if you are not including sensitive information as clear text.
         /// This flag will overridde any behavior configured by <see cref="XRayOptions.CollectSqlQueries" />.
-        /// If a value is not provided, then the globally configured value will be used, which is fals by default.
+        /// If a value is not provided, then the globally configured value will be used, which is false by default.
+        /// See the official documentation on <a href="https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.parameters?view=netframework-4.7.2">SqlCommand.Parameters</a>
         /// </param>
         public TraceableSqlCommand(string cmdText, SqlConnection connection, SqlTransaction transaction, bool? collectSqlQueries = null)
         {
@@ -426,7 +430,7 @@ namespace Amazon.XRay.Recorder.Handlers.SqlServer
             return InnerSqlCommand.ExecuteReader(behavior);
         }
 
-        protected async Task<TResult> InterceptAsync<TResult>(Func<Task<TResult>> method)
+        protected virtual async Task<TResult> InterceptAsync<TResult>(Func<Task<TResult>> method)
             => await _interceptor.InterceptAsync(method, this);
 
         protected virtual TResult Intercept<TResult>(Func<TResult> method)

--- a/sdk/src/Handlers/SqlServer/TraceableSqlCommand.netstandard.cs
+++ b/sdk/src/Handlers/SqlServer/TraceableSqlCommand.netstandard.cs
@@ -23,6 +23,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Amazon.XRay.Recorder.Core;
+using Amazon.XRay.Recorder.Core.Internal.Utils;
 
 namespace Amazon.XRay.Recorder.Handlers.SqlServer
 {

--- a/sdk/src/Handlers/SqlServer/TraceableSqlCommand.netstandard.cs
+++ b/sdk/src/Handlers/SqlServer/TraceableSqlCommand.netstandard.cs
@@ -454,6 +454,7 @@ namespace Amazon.XRay.Recorder.Handlers.SqlServer
 
             recorder.AddSqlInformation("user", connectionStringBuilder.UserID);
             recorder.AddSqlInformation("connection_string", connectionStringBuilder.ToString());
+            recorder.AddSqlInformation("sanitized_query", CommandText);
         }
     }
 }

--- a/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
+++ b/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
@@ -79,6 +79,7 @@
     <Compile Remove="TestXRayOptions.cs" />
     <Compile Remove="TestLambdaContext.cs" />
     <Compile Remove="FacadeSegmentTest.cs" />
+    <Compile Remove="DbCommandInterceptorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Web" />

--- a/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
+++ b/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
@@ -87,6 +87,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="JSONs\Appsetting\CollectSqlQueriesFalse.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="JSONs\Appsetting\CollectSqlQueriesTrue.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="JSONs\Appsetting\NoXRaySection.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/sdk/test/UnitTests/DbCommandInterceptorTests.cs
+++ b/sdk/test/UnitTests/DbCommandInterceptorTests.cs
@@ -1,0 +1,223 @@
+//-----------------------------------------------------------------------------
+// <copyright file="JsonSegmentMarshallerTest.cs" company="Amazon.com">
+//      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+//      Licensed under the Apache License, Version 2.0 (the "License").
+//      You may not use this file except in compliance with the License.
+//      A copy of the License is located at
+//
+//      http://aws.amazon.com/apache2.0
+//
+//      or in the "license" file accompanying this file. This file is distributed
+//      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//      express or implied. See the License for the specific language governing
+//      permissions and limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using System.Data;
+using System.Data.Common;
+using System.Data.SqlClient;
+using Amazon.XRay.Recorder.Handlers.SqlServer;
+using Amazon.XRay.Recorder.Core.Internal.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Amazon.XRay.Recorder.Core;
+using Amazon.XRay.Recorder.UnitTests.Tools;
+using Newtonsoft.Json;
+
+namespace Amazon.XRay.Recorder.UnitTests
+{
+    [TestClass]
+    public class DbCommandInterceptorTests : TestBase
+    {
+        private DbCommandStub _command = new DbCommandStub();
+
+        [TestInitialize]
+        public void TestInitialize() 
+        {
+            var connectionMock = new Mock<DbConnection>();
+            connectionMock.Setup(c => c.DataSource).Returns("xyz.com,3306");
+            connectionMock.Setup(c => c.Database).Returns("master");
+            connectionMock.Setup(c => c.ServerVersion).Returns("13.0.5026.0");
+            connectionMock.Setup(c => c.ConnectionString).Returns("Data Source=xyz.com,3306;User ID=admin;Password=Secret.123;");
+
+            _command.Connection = connectionMock.Object;
+            _command.CommandText = "SELECT a.* FROM dbo.Accounts a ...";
+        }
+
+        [TestCleanup]
+        public new void TestCleanup()
+        {
+            base.TestCleanup();
+            AWSXRayRecorder.Instance.Dispose();
+        }
+
+        [TestMethod]
+        public void Intercept_DoesNot_CollectQueries_When_NotEnabled()
+        {
+            // arrange
+            var recorder = new AWSXRayRecorder {
+                XRayOptions = new XRayOptions()
+            };
+            recorder.BeginSegment("test");
+            var interceptor = new DbCommandInterceptor(recorder);
+
+            // act
+            interceptor.Intercept(() => 0, _command);
+
+            // assert
+            var segment = AWSXRayRecorder.Instance.TraceContext.GetEntity();
+            
+            AssertNotCollected(recorder);
+            recorder.EndSegment();
+        }
+
+        [TestMethod]
+        public async Task InterceptAsync_DoesNot_CollectQueries_When_NotEnabled()
+        {
+            // arrange
+            var recorder = new AWSXRayRecorder {
+                XRayOptions = new XRayOptions()
+            };
+            recorder.BeginSegment("test");
+            var interceptor = new DbCommandInterceptor(recorder);
+
+            // act
+            await interceptor.InterceptAsync(() => Task.FromResult(0), _command);
+
+            // assert
+            var segment = AWSXRayRecorder.Instance.TraceContext.GetEntity();
+            
+            AssertNotCollected(recorder);
+            recorder.EndSegment();
+        }
+
+        [TestMethod]
+        public void Intercept_CollectsQueries_When_DisabledGlobally_And_EnabledLocally()
+        {
+            // arrange
+            var recorder = new AWSXRayRecorder {
+                XRayOptions = new XRayOptions { CollectSqlQueries = false }
+            };
+            recorder.BeginSegment("test");
+            var interceptor = new DbCommandInterceptor(recorder, collectSqlQueries: true);
+
+            // act            
+            interceptor.Intercept(() => 0, _command);
+
+            // assert
+            AssertCollected(recorder);
+            recorder.EndSegment();
+        }
+
+        [TestMethod]
+        public async Task InterceptAsync_CollectsQueries_When_DisabledGlobally_And_EnabledLocally()
+        {
+            // arrange
+            var recorder = new AWSXRayRecorder {
+                XRayOptions = new XRayOptions { CollectSqlQueries = false }
+            };
+            recorder.BeginSegment("test");
+            var interceptor = new DbCommandInterceptor(recorder, collectSqlQueries: true);
+
+            // act            
+            await interceptor.InterceptAsync(() => Task.FromResult(0), _command);
+
+            // assert
+            AssertCollected(recorder);
+            recorder.EndSegment();
+        }
+
+        [TestMethod]
+        public void Intercept_CollectsQueries_When_EnabledGlobally()
+        {
+            // arrange
+            var recorder = new AWSXRayRecorder {
+                XRayOptions = new XRayOptions { CollectSqlQueries = true }
+            };
+            var interceptor = new DbCommandInterceptor(recorder);
+            recorder.BeginSegment("test");
+
+            // act
+            interceptor.Intercept(() => 0, _command);
+
+            // assert
+            AssertCollected(recorder);
+            recorder.EndSegment();
+        }
+
+        [TestMethod]
+        public async Task InterceptAsync_CollectsQueries_When_EnabledGlobally()
+        {
+            // arrange
+            var recorder = new AWSXRayRecorder {
+                XRayOptions = new XRayOptions { CollectSqlQueries = true }
+            };
+            var interceptor = new DbCommandInterceptor(recorder);
+            recorder.BeginSegment("test");
+
+            // act
+            await interceptor.InterceptAsync(() => Task.FromResult(0), _command);
+
+            // assert
+            AssertCollected(recorder);
+            recorder.EndSegment();
+        }
+
+        [TestMethod]
+        public void Intercept_DoesNot_CollectQueries_When_EnabledGlobally_And_DisabledLocally()
+        {
+            // arrange
+            var recorder = new AWSXRayRecorder {
+                XRayOptions = new XRayOptions { CollectSqlQueries = true }
+            };
+            var interceptor = new DbCommandInterceptor(recorder, collectSqlQueries: false);
+            recorder.BeginSegment("test");
+
+            // act
+            interceptor.Intercept(() => 0, _command);
+
+            // assert
+            AssertNotCollected(recorder);
+            recorder.EndSegment();
+        }
+
+        [TestMethod]
+        public async Task InterceptAsync_DoesNot_CollectQueries_When_EnabledGlobally_And_DisabledLocally()
+        {
+            // arrange
+            var recorder = new AWSXRayRecorder {
+                XRayOptions = new XRayOptions { CollectSqlQueries = true }
+            };
+            var interceptor = new DbCommandInterceptor(recorder, collectSqlQueries: false);
+            recorder.BeginSegment("test");
+
+            // act
+            await interceptor.InterceptAsync(() => Task.FromResult(0), _command);
+
+            // assert
+            AssertNotCollected(recorder);
+            recorder.EndSegment();
+        }
+
+        private void AssertNotCollected(AWSXRayRecorder recorder)
+        {
+            var segment = recorder.TraceContext.GetEntity().Subsegments[0];
+            Assert.IsNotNull(segment);
+            Assert.AreEqual(4, segment.Sql.Count);
+            Assert.IsFalse(segment.Sql.ContainsKey("sanitized_query"));
+        }
+
+        private void AssertCollected(AWSXRayRecorder recorder)
+        {
+            var segment = recorder.TraceContext.GetEntity().Subsegments[0];
+            Assert.IsNotNull(segment);
+            Assert.AreEqual(5, segment.Sql.Count);
+            Assert.IsTrue(segment.Sql.ContainsKey("sanitized_query"));
+            Assert.AreEqual(_command.CommandText, segment.Sql["sanitized_query"]);
+        }
+    }
+}

--- a/sdk/test/UnitTests/JSONs/Appsetting/CollectSqlQueriesFalse.json
+++ b/sdk/test/UnitTests/JSONs/Appsetting/CollectSqlQueriesFalse.json
@@ -1,0 +1,5 @@
+﻿{
+    "XRay": {
+        "CollectSqlQueries": "false"
+    }
+}

--- a/sdk/test/UnitTests/JSONs/Appsetting/CollectSqlQueriesTrue.json
+++ b/sdk/test/UnitTests/JSONs/Appsetting/CollectSqlQueriesTrue.json
@@ -1,0 +1,5 @@
+﻿{
+    "XRay": {
+        "CollectSqlQueries": "true"
+    }
+}

--- a/sdk/test/UnitTests/TestXRayOptions.cs
+++ b/sdk/test/UnitTests/TestXRayOptions.cs
@@ -213,6 +213,36 @@ namespace Amazon.XRay.Recorder.UnitTests
             Assert.AreEqual(AWSXRayRecorder.Instance.ContextMissingStrategy, Core.Strategies.ContextMissingStrategy.RUNTIME_ERROR);
         }
 
+        [TestMethod]
+        public void TestCollectSqlQueriesFalse_WhenNotSpecifiedInJson()
+        {
+            IConfiguration configuration = BuildConfiguration("DisabledXRayMissing.json");
+            _xRayOptions = XRayConfiguration.GetXRayOptions(configuration);
+            AWSXRayRecorder.InitializeInstance(configuration);
+
+            Assert.IsFalse(_xRayOptions.CollectSqlQueries);
+        }
+
+        [TestMethod]
+        public void TestCollecSqlQueriesFalse()
+        {
+            IConfiguration configuration = BuildConfiguration("CollectSqlQueriesFalse.json");
+            _xRayOptions = XRayConfiguration.GetXRayOptions(configuration);
+            AWSXRayRecorder.InitializeInstance(configuration);
+
+            Assert.IsFalse(_xRayOptions.CollectSqlQueries);
+        }
+
+        [TestMethod]
+        public void TestCollecSqlQueriesTrue()
+        {
+            IConfiguration configuration = BuildConfiguration("CollectSqlQueriesTrue.json");
+            _xRayOptions = XRayConfiguration.GetXRayOptions(configuration);
+            AWSXRayRecorder.InitializeInstance(configuration);
+
+            Assert.IsTrue(_xRayOptions.CollectSqlQueries);
+        }
+
         // Creating custom configuration
         private IConfiguration BuildConfiguration(string path)
         {

--- a/sdk/test/UnitTests/Tools/DbCommandStub.cs
+++ b/sdk/test/UnitTests/Tools/DbCommandStub.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------------
-// <copyright file="JsonSegmentMarshallerTest.cs" company="Amazon.com">
+// <copyright file="DbCommandStub.cs" company="Amazon.com">
 //      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 //      Licensed under the Apache License, Version 2.0 (the "License").

--- a/sdk/test/UnitTests/Tools/DbCommandStub.cs
+++ b/sdk/test/UnitTests/Tools/DbCommandStub.cs
@@ -1,0 +1,62 @@
+//-----------------------------------------------------------------------------
+// <copyright file="JsonSegmentMarshallerTest.cs" company="Amazon.com">
+//      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+//      Licensed under the Apache License, Version 2.0 (the "License").
+//      You may not use this file except in compliance with the License.
+//      A copy of the License is located at
+//
+//      http://aws.amazon.com/apache2.0
+//
+//      or in the "license" file accompanying this file. This file is distributed
+//      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//      express or implied. See the License for the specific language governing
+//      permissions and limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Data.SqlClient;
+
+// This class exists because DbCommand has non-abstract members
+// that cannot be mocked, but need to be used. A specific example is
+// DbCommand.Connection. This property needs to be used, but the getters
+// and setters cannot be mocked. Instead, this class inherits from DbCommand
+// allowing the base implementations to be invoked.
+// REF: https://github.com/dotnet/corefx/blob/84bedcf58cfe951d37c5b3eba2957ddb2410f34d/src/System.Data.Common/src/System/Data/Common/DbCommand.cs#L30
+namespace Amazon.XRay.Recorder.UnitTests.Tools
+{
+    public class DbCommandStub : DbCommand
+    {
+        private object _scalarResult = null;
+        private int _nonQueryResult = 0;
+        private DbDataReader _dbDataReader = null;
+        private DbParameter _createDbParameterResult = null;
+
+        // setup methods
+        public void WithScalarResult(object _) => _scalarResult = _;
+        public void WithNonQueryResult(int _) => _nonQueryResult = _;
+        public void WithDbReader(DbDataReader _) => _dbDataReader = _;
+        public void WithCreateDbParameterResult(DbParameter _) => _createDbParameterResult = _;
+
+        // stubbed methods
+        public override string CommandText { get; set; }
+        public override int CommandTimeout { get; set; }
+        public override CommandType CommandType { get; set; }
+        protected override DbConnection DbConnection { get; set; }
+        protected override DbParameterCollection DbParameterCollection { get; }
+        protected override DbTransaction DbTransaction { get; set; }
+        public override bool DesignTimeVisible { get; set; }
+        public override UpdateRowSource UpdatedRowSource { get; set; }
+        public override void Cancel() { }
+        protected override DbParameter CreateDbParameter() => _createDbParameterResult;
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+            => _dbDataReader;
+
+        public override int ExecuteNonQuery() => _nonQueryResult;
+        public override object ExecuteScalar() => _scalarResult;
+        public override void Prepare() { }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Adds the parameterized SQL command to the metadata. I tried adding it using the `AddSqlInformation` API, but it isn't available in the console/UI so I suspect there is a requisite backend change to handle this. I don't really expect this to get merged, but hope to either get some advice on how this _should_ be done today, or start a discussion on how it should be done in the future.

Example content of `CommandText` (generated by EntityFrameworkCore):

```
SELECT TOP(1) [e].[Id], [e].[Name]\nFROM [users] AS [e]\nWHERE [e].[Id] = @__get_User_0
```

It would be nice to strip the newlines out or pretty print them. That probably shouldn't be done application side since it could result in lots of string allocations, but it might make sense on the console side of things, especially if it receives special treatment as SQL command text.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
