### PR TITLE
Fixing bug in RequestUtil.ProcessRequest

### DIFF
--- a/sdk/src/Handlers/System.Net/Utils/RequestUtil.cs
+++ b/sdk/src/Handlers/System.Net/Utils/RequestUtil.cs
@@ -64,11 +64,11 @@ namespace Amazon.XRay.Recorder.Handlers.System.Net.Utils
                     ["method"] = method
                 };
                 AWSXRayRecorder.Instance.AddHttpInformation("request", requestInformation);
-            }
-
-            if (TraceHeader.TryParse(AWSXRayRecorder.Instance.TraceContext.GetEntity(), out var header))
-            {
-                addHeaderAction(header.ToString());
+                
+                if (TraceHeader.TryParse(AWSXRayRecorder.Instance.TraceContext.GetEntity(), out var header))
+                {
+                    addHeaderAction(header.ToString());
+                }
             }
         }
 

--- a/sdk/test/UnitTests/HttpClientXRayTracingHandlerTests.cs
+++ b/sdk/test/UnitTests/HttpClientXRayTracingHandlerTests.cs
@@ -70,11 +70,11 @@ namespace Amazon.XRay.Recorder.UnitTests
         }
         
         /// <summary>
-        /// Ensures that when tracing is disabled that HTTP requests can execute as normal. \
+        /// Ensures that when tracing is disabled that HTTP requests can execute as normal.
         /// See https://github.com/aws/aws-xray-sdk-dotnet/issues/57 for more information. 
         /// </summary>
         [TestMethod]
-        public async Task TestSendAsync_XrayDisabled()
+        public async Task TestXrayDisabledSendAsync()
         {
             _recorder = new MockAWSXRayRecorder() { IsTracingDisabledValue = true };
 #if NET45

--- a/sdk/test/UnitTests/HttpClientXRayTracingHandlerTests.cs
+++ b/sdk/test/UnitTests/HttpClientXRayTracingHandlerTests.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Amazon.XRay.Recorder.Core;
 using Amazon.XRay.Recorder.Core.Internal.Entities;
 using Amazon.XRay.Recorder.Core.Internal.Utils;
 using Amazon.XRay.Recorder.Handlers.System.Net;
+using Amazon.XRay.Recorder.UnitTests.Tools;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Amazon.XRay.Recorder.UnitTests
@@ -50,8 +52,8 @@ namespace Amazon.XRay.Recorder.UnitTests
         {
             AWSXRayRecorder.Instance.BeginSegment("parent", TraceId);
             var request = new HttpRequestMessage(HttpMethod.Get, URL);
-            var response = await _httpClient.SendAsync(request);
-            
+            using(await _httpClient.SendAsync(request)) {}
+
             var segment = AWSXRayRecorder.Instance.TraceContext.GetEntity();
             AWSXRayRecorder.Instance.EndSegment();
 
@@ -66,14 +68,37 @@ namespace Amazon.XRay.Recorder.UnitTests
             Assert.AreEqual(200, responseInfo["status"]);
             Assert.IsNotNull(responseInfo["content_length"]);
         }
+        
+        /// <summary>
+        /// Ensures that when tracing is disabled that HTTP requests can execute as normal. \
+        /// See https://github.com/aws/aws-xray-sdk-dotnet/issues/57 for more information. 
+        /// </summary>
+        [TestMethod]
+        public async Task TestSendAsync_XrayDisabled()
+        {
+            _recorder = new MockAWSXRayRecorder() { IsTracingDisabledValue = true };
+#if NET45
+            AWSXRayRecorder.InitializeInstance(_recorder);
+#else
+            AWSXRayRecorder.InitializeInstance(recorder: _recorder);
+# endif
+            Assert.IsTrue(AWSXRayRecorder.Instance.IsTracingDisabled());
+            
+            var request = new HttpRequestMessage(HttpMethod.Get, URL);
+            using (var response = await _httpClient.SendAsync(request))
+            {
+                Assert.IsNotNull(response);
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
 
         [TestMethod]
         public async Task Test404SendAsync()
         {
             AWSXRayRecorder.Instance.BeginSegment("parent", TraceId);
             var request = new HttpRequestMessage(HttpMethod.Get, URL404);
-            var response = await _httpClient.SendAsync(request);
-            
+            using(await _httpClient.SendAsync(request)) {}
+
             var segment = AWSXRayRecorder.Instance.TraceContext.GetEntity();
             AWSXRayRecorder.Instance.EndSegment();
 

--- a/sdk/test/UnitTests/HttpWebRequestTracingExtensionTests.cs
+++ b/sdk/test/UnitTests/HttpWebRequestTracingExtensionTests.cs
@@ -80,11 +80,11 @@ namespace Amazon.XRay.Recorder.UnitTests
         }
         
         /// <summary>
-        /// Ensures that when tracing is disabled that HTTP requests can execute as normal. \
+        /// Ensures that when tracing is disabled that HTTP requests can execute as normal.
         /// See https://github.com/aws/aws-xray-sdk-dotnet/issues/57 for more information. 
         /// </summary>
         [TestMethod]
-        public void TestGetResponseTraced_XrayDisabled()
+        public void TestXrayDisabledGetResponseTraced()
         {
             _recorder = new MockAWSXRayRecorder() { IsTracingDisabledValue = true };
 #if NET45
@@ -123,6 +123,30 @@ namespace Amazon.XRay.Recorder.UnitTests
                 var responseInfo = segment.Subsegments[0].Http["response"] as Dictionary<string, object>;
                 Assert.AreEqual(200, responseInfo["status"]);
                 Assert.IsNotNull(responseInfo["content_length"]);
+            }
+        }
+        
+        /// <summary>
+        /// Ensures that when tracing is disabled that HTTP requests can execute as normal.
+        /// See https://github.com/aws/aws-xray-sdk-dotnet/issues/57 for more information. 
+        /// </summary>
+        [TestMethod]
+        public async Task TestXrayDisabledGetAsyncResponseTraced()
+        {
+            _recorder = new MockAWSXRayRecorder() { IsTracingDisabledValue = true };
+#if NET45
+            AWSXRayRecorder.InitializeInstance(_recorder);
+#else
+            AWSXRayRecorder.InitializeInstance(recorder: _recorder);
+# endif
+            Assert.IsTrue(AWSXRayRecorder.Instance.IsTracingDisabled());
+
+            var request = (HttpWebRequest)WebRequest.Create(URL);
+            
+            using (var response = await request.GetAsyncResponseTraced() as HttpWebResponse)
+            {
+                Assert.IsNotNull(response);
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             }
         }
 

--- a/sdk/test/UnitTests/Tools/MockAWSXRayRecorder.cs
+++ b/sdk/test/UnitTests/Tools/MockAWSXRayRecorder.cs
@@ -1,0 +1,14 @@
+using Amazon.XRay.Recorder.Core;
+
+namespace Amazon.XRay.Recorder.UnitTests.Tools
+{
+    public class MockAWSXRayRecorder : AWSXRayRecorder
+    {
+        public bool IsTracingDisabledValue { get; set; }
+        
+        public override bool IsTracingDisabled()
+        {
+            return IsTracingDisabledValue;
+        }
+    }
+}


### PR DESCRIPTION
*Issue:* https://github.com/aws/aws-xray-sdk-dotnet/issues/57

*Description of changes:*
Don't access the trace context in `RequestUtil.ProcessRequest` when tracing is disabled. See  for more information.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
