### PR TITLE
Bug fix - Calling AddMetadata twice with the same key should overwrit…

### DIFF
--- a/sdk/src/Core/Internal/Entities/Entity.cs
+++ b/sdk/src/Core/Internal/Entities/Entity.cs
@@ -505,7 +505,7 @@ namespace Amazon.XRay.Recorder.Core.Internal.Entities
         /// <param name="value">The value.</param>
         public void AddMetadata(string nameSpace, string key, object value)
         {
-            _lazyMetadata.Value.GetOrAdd(nameSpace, new ConcurrentDictionary<string, object>()).Add(key, value);
+            _lazyMetadata.Value.GetOrAdd(nameSpace, new ConcurrentDictionary<string, object>())[key] = value;
         }
 
         /// <summary>

--- a/sdk/test/UnitTests/AWSXRayRecorderTests.cs
+++ b/sdk/test/UnitTests/AWSXRayRecorderTests.cs
@@ -184,7 +184,7 @@ namespace Amazon.XRay.Recorder.UnitTests
         }
 
         [TestMethod]
-        public void TestCreateThunsandSubsegmentsParallel()
+        public void TestCreateThousandSubsegmentsParallel()
         {
             _recorder.BeginSegment("parent", TraceId);
             Segment parent = (Segment)AWSXRayRecorder.Instance.TraceContext.GetEntity();
@@ -813,6 +813,23 @@ namespace Amazon.XRay.Recorder.UnitTests
 
             Assert.AreEqual("value1", segment.Metadata["default"]["key1"]);
             Assert.AreEqual("value2", segment.Metadata["aws"]["key2"]);
+        }
+
+        [TestMethod]
+        public void TestUpdateMetadata()
+        {
+            _recorder.BeginSegment("metadata", TraceId);
+            _recorder.AddMetadata("key1", "value1");
+            _recorder.AddMetadata("key1", "updated1");
+
+            _recorder.AddMetadata("aws", "key2", "value2");
+            _recorder.AddMetadata("aws", "key2", "updated2");
+
+            var segment = AWSXRayRecorder.Instance.TraceContext.GetEntity();
+            _recorder.EndSegment();
+
+            Assert.AreEqual("updated1", segment.Metadata["default"]["key1"]);
+            Assert.AreEqual("updated2", segment.Metadata["aws"]["key2"]);
         }
 
         [TestMethod]


### PR DESCRIPTION
…es previously recorded values

*Issue #, if available:*
#59 

*Description of changes:*
Calling AddMetadata twice with the same key should overwrites previously recorded values

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
