### PR TITLE
Issue #61: Add option to register XRay manifest from embedded resource

### DIFF
--- a/sdk/src/Handlers/AwsSdk/AWSSDKHandler.cs
+++ b/sdk/src/Handlers/AwsSdk/AWSSDKHandler.cs
@@ -17,6 +17,7 @@
 using Amazon.Runtime.Internal;
 using Amazon.XRay.Recorder.Handlers.AwsSdk.Internal;
 using System;
+using System.IO;
 
 namespace Amazon.XRay.Recorder.Handlers.AwsSdk
 {
@@ -44,7 +45,7 @@ namespace Amazon.XRay.Recorder.Handlers.AwsSdk
         {
             _customizer = GetCustomizer();
             _customizer.RegisterAll = true;
-            _customizer.Path = path;
+            _customizer.XRayPipelineHandler = new XRayPipelineHandler(path);
         }
 
         /// <summary>
@@ -59,11 +60,21 @@ namespace Amazon.XRay.Recorder.Handlers.AwsSdk
         /// <summary>
         /// Registers file path of AWS Service Manifest file. This file would be used for all the registered <see cref="Runtime.AmazonServiceClient"/> instances. 
         /// </summary>
-        ///  <param name="path"> Absolute path to the file which contains the operation parameter whitelist configuration.</param>
+        /// <param name="path"> Absolute path to the file which contains the operation parameter whitelist configuration.</param>
         public static void RegisterXRayManifest(String path)
         {
             _customizer = GetCustomizer();
-            _customizer.Path = path;
+            _customizer.XRayPipelineHandler = new XRayPipelineHandler(path);
+        }
+
+        /// <summary>
+        /// Registers AWS Service Manifest resource stream. This stream would be used for all the registered <see cref="Runtime.AmazonServiceClient"/> instances. 
+        /// </summary>
+        /// <param name="stream"> stream for manifest which contains the operation parameter whitelist configuration.</param>
+        public static void RegisterXRayManifest(Stream stream)
+        {
+            _customizer = GetCustomizer();
+            _customizer.XRayPipelineHandler = new XRayPipelineHandler(stream);
         }
 
         private static XRayPipelineCustomizer GetCustomizer()

--- a/sdk/src/Handlers/AwsSdk/Internal/XRayPipelineHandler.cs
+++ b/sdk/src/Handlers/AwsSdk/Internal/XRayPipelineHandler.cs
@@ -103,7 +103,15 @@ namespace Amazon.XRay.Recorder.Handlers.AwsSdk.Internal
                 throw new ArgumentNullException("recorder");
             }
 
-            Init(_recorder, stream);
+            if (stream == null)
+            {
+                _logger.DebugFormat("The provided stream is null, initializing with default AWS whitelist.");
+                InitWithDefaultAWSWhitelist(_recorder);
+            }
+            else
+            {
+                Init(_recorder, stream);
+            }
         }
 
         private static bool TryReadPropertyValue(object obj, string propertyName, out object value)

--- a/sdk/test/UnitTests/AWSSDKHandlerTests.cs
+++ b/sdk/test/UnitTests/AWSSDKHandlerTests.cs
@@ -132,6 +132,14 @@ namespace Amazon.XRay.Recorder.UnitTests
         }
 
         [TestMethod]
+        public void TestLoadServiceHandlerManifestWithDefaultConfigurationForAWSSDKHandlerNullStream()
+        {
+            Stream stream = null;
+            var handler = new XRayPipelineHandler(stream);
+            Assert.IsNotNull(handler.AWSServiceHandlerManifest);
+        }
+
+        [TestMethod]
         public void TestLoadServiceHandlerManifestWithDefaultConfigurationForAWSSDKHandlerAsStream()
         {
             using (Stream stream = new FileStream(_path, FileMode.Open, FileAccess.Read))

--- a/sdk/test/UnitTests/AWSSDKHandlerTests.cs
+++ b/sdk/test/UnitTests/AWSSDKHandlerTests.cs
@@ -132,6 +132,16 @@ namespace Amazon.XRay.Recorder.UnitTests
         }
 
         [TestMethod]
+        public void TestLoadServiceHandlerManifestWithDefaultConfigurationForAWSSDKHandlerAsStream()
+        {
+            using (Stream stream = new FileStream(_path, FileMode.Open, FileAccess.Read))
+            {
+                var handler = new XRayPipelineHandler(stream);
+                Assert.IsNotNull(handler.AWSServiceHandlerManifest);
+            }
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(FileNotFoundException))]
         public void TestLoadServiceInfoManifestInvalidPathForAWSSDKHandler()
         {
@@ -273,6 +283,34 @@ namespace Amazon.XRay.Recorder.UnitTests
 
             Assert.AreEqual("Invoke", segment.Subsegments[0].Aws["operation"]);
             Assert.AreEqual("testFunction", segment.Subsegments[0].Aws["function_name"]);
+        }
+
+        [TestMethod]
+        public void TestRegisterXRayManifestWithStreamLambdaForAWSSDKHandler()
+        {
+            String temp_path = $"JSONs{Path.DirectorySeparatorChar}AWSRequestInfoWithLambda.json"; //registering manifest file with Lambda
+            using (Stream stream = new FileStream(temp_path, FileMode.Open, FileAccess.Read))
+            {
+                AWSSDKHandler.RegisterXRayManifest(stream);
+            }
+            var lambda = new AmazonLambdaClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
+            CustomResponses.SetResponse(lambda, null, null, true);
+            _recorder.BeginSegment("lambda", TraceId);
+#if NET45
+            lambda.Invoke(new InvokeRequest
+            {
+                FunctionName = "testFunction"
+            });
+#else
+            lambda.InvokeAsync(new InvokeRequest
+            {
+                FunctionName = "testFunction"
+            }).Wait();
+#endif
+            var segment = AWSXRayRecorder.Instance.TraceContext.GetEntity();
+            _recorder.EndSegment();
+
+            Assert.AreEqual("Invoke", segment.Subsegments[0].Aws["operation"]);
         }
     }
 }


### PR DESCRIPTION
*Issue #61 :* Add option to register XRay manifest from embedded resource

*Description of changes:*

Added alternate `RegisterXRayManifest()` method which takes a `Stream` instead of a file path. To prevent having to leave the `Stream` open, modified `XRayPipelineCustomizer` to carry the `XRayPipelineHandler` rather than `Path` attribute so the manifest can be initialized on the call the `RegisterXRayManifest()` rather than the call to `Customize()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
