### PR TITLE
Initializes the static instance in AWSXrayRecorder to fix #67

### DIFF
--- a/sdk/src/Core/AWSXRayRecorder.netcore.cs
+++ b/sdk/src/Core/AWSXRayRecorder.netcore.cs
@@ -32,7 +32,7 @@ namespace Amazon.XRay.Recorder.Core
     public class AWSXRayRecorder : AWSXRayRecorderImpl
     {
         private static readonly Logger _logger = Logger.GetLogger(typeof(AWSXRayRecorder));
-        static AWSXRayRecorder _instance;
+        static AWSXRayRecorder _instance = new AWSXRayRecorderBuilder().Build();
         public const String LambdaTaskRootKey = "LAMBDA_TASK_ROOT";
         public const String LambdaTraceHeaderKey = "_X_AMZN_TRACE_ID";
 


### PR DESCRIPTION
*Issue #, if available:* #67 

*Description of changes:* This adds a lock on the custom_exporters_table Dictionary and checks to see if it is null before moving forward. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
