### PR TITLE
Custom timestamp for subsegment

### DIFF
--- a/sdk/src/Core/AWSXRayRecorder.cs
+++ b/sdk/src/Core/AWSXRayRecorder.cs
@@ -97,9 +97,10 @@ namespace Amazon.XRay.Recorder.Core
         /// Begin a tracing subsegment. A new segment will be created and added as a subsegment to previous segment.
         /// </summary>
         /// <param name="name">Name of the operation.</param>
+        /// <param name="timestamp">Sets the start time for the subsegment.</param>
         /// <exception cref="ArgumentNullException">The argument has a null value.</exception>
         /// <exception cref="EntityNotAvailableException">Entity is not available in trace context.</exception>
-        public override void BeginSubsegment(string name)
+        public override void BeginSubsegment(string name, DateTime? timestamp = null)
         {
             try
             {
@@ -124,7 +125,15 @@ namespace Amazon.XRay.Recorder.Core
                 Subsegment subsegment = new Subsegment(name);
                 parentEntity.AddSubsegment(subsegment);
                 subsegment.Sampled = parentEntity.Sampled;
-                subsegment.SetStartTimeToNow();
+                if (timestamp == null)
+                {
+                    subsegment.SetStartTimeToNow();
+                }
+                else
+                {
+                    subsegment.SetStartTime(timestamp.Value);
+                }
+                
                 TraceContext.SetEntity(subsegment);
             }
             catch (EntityNotAvailableException e)
@@ -136,8 +145,9 @@ namespace Amazon.XRay.Recorder.Core
         /// <summary>
         /// End a subsegment.
         /// </summary>
+        /// <param name="timestamp">Sets the end time of the subsegment</param>
         /// <exception cref="EntityNotAvailableException">Entity is not available in trace context.</exception>
-        public override void EndSubsegment()
+        public override void EndSubsegment(DateTime? timestamp = null)
         {
             try
             {
@@ -147,7 +157,7 @@ namespace Amazon.XRay.Recorder.Core
                     return;
                 }
 
-                ProcessEndSubsegment();
+                ProcessEndSubsegment(timestamp);
             }
             catch (EntityNotAvailableException e)
             {

--- a/sdk/src/Core/IAWSXRayRecorder.cs
+++ b/sdk/src/Core/IAWSXRayRecorder.cs
@@ -92,12 +92,14 @@ namespace Amazon.XRay.Recorder.Core
         /// Start a subsegment with a given segment
         /// </summary>
         /// <param name="name">Name of the operation</param>
-        void BeginSubsegment(string name);
+        /// <param name="timestamp">Sets the start time for the subsegment</param>
+        void BeginSubsegment(string name, DateTime? timestamp = null);
 
         /// <summary>
         /// End a subsegment
         /// </summary>
-        void EndSubsegment();
+        /// <param name="timestamp">Sets the end time for the subsegment</param>
+        void EndSubsegment(DateTime? timestamp = null);
 
         /// <summary>
         /// Set namespace to current segment

--- a/sdk/src/Core/Internal/Entities/Entity.cs
+++ b/sdk/src/Core/Internal/Entities/Entity.cs
@@ -382,7 +382,7 @@ namespace Amazon.XRay.Recorder.Core.Internal.Entities
         }
 
         /// <summary>
-        /// Set start time of the segment to current time
+        /// Set start time of the entity to current time
         /// </summary>
         public void SetStartTimeToNow()
         {
@@ -390,11 +390,42 @@ namespace Amazon.XRay.Recorder.Core.Internal.Entities
         }
 
         /// <summary>
-        /// Set end time of the segment to current time
+        /// Set end time of the entity to current time
         /// </summary>
         public void SetEndTimeToNow()
         {
             EndTime = DateTime.UtcNow.ToUnixTimeSeconds();
+        }
+
+        /// <summary>
+        /// Sets start time of the entity to the provided timestamp.
+        /// </summary>
+        public void SetStartTime(decimal timestamp)
+        {
+            StartTime = timestamp;
+        }
+        /// <summary>
+        /// Sets end time of the entity to the provided timestamp.
+        /// </summary>
+        public void SetEndTime(decimal timestamp)
+        {
+            EndTime = timestamp;
+        }
+
+        /// <summary>
+        /// Sets start time of the entity to the provided timestamp.
+        /// </summary>
+        public void SetStartTime(DateTime timestamp)
+        {
+            StartTime = TimeStamp.ToUnixSeconds(timestamp);
+        }
+
+        /// <summary>
+        /// Sets end time of the entity to the provided timestamp.
+        /// </summary>
+        public void SetEndTime(DateTime timestamp)
+        {
+            EndTime = TimeStamp.ToUnixSeconds(timestamp);
         }
 
         /// <summary>

--- a/sdk/src/Core/Internal/Entities/Segment.cs
+++ b/sdk/src/Core/Internal/Entities/Segment.cs
@@ -131,36 +131,5 @@ namespace Amazon.XRay.Recorder.Core.Internal.Entities
         {
             return Reference == 0;
         }
-
-        /// <summary>
-        /// Sets start time of the segment to the provided timestamp.
-        /// </summary>
-        public void SetStartTime(decimal timestamp)
-        {
-            StartTime = timestamp; 
-        }
-        /// <summary>
-        /// Sets end time of the segment to the provided timestamp.
-        /// </summary>
-        public void SetEndTime(decimal timestamp)
-        {
-            EndTime = timestamp;
-        }
-
-        /// <summary>
-        /// Sets start time of the segment to the provided timestamp.
-        /// </summary>
-        public void SetStartTime(DateTime timestamp)
-        {
-            StartTime = TimeStamp.ToUnixSeconds(timestamp);
-        }
-
-        /// <summary>
-        /// Sets end time of the segment to the provided timestamp.
-        /// </summary>
-        public void SetEndTime(DateTime timestamp)
-        {
-            EndTime = TimeStamp.ToUnixSeconds(timestamp);
-        }
     }
 }

--- a/sdk/src/Core/Sampling/TimeStamp.cs
+++ b/sdk/src/Core/Sampling/TimeStamp.cs
@@ -94,7 +94,7 @@ namespace Amazon.XRay.Recorder.Core.Sampling
 
         private static decimal GetUnixSeconds(DateTime utcNow)
         {
-            return decimal.Floor(DateTime.UtcNow.ToUnixTimeSeconds());
+            return decimal.Floor(utcNow.ToUnixTimeSeconds());
         }
     }
 }

--- a/sdk/test/UnitTests/AWSXRayRecorderTests.cs
+++ b/sdk/test/UnitTests/AWSXRayRecorderTests.cs
@@ -1061,7 +1061,7 @@ namespace Amazon.XRay.Recorder.UnitTests
             recorder.BeginSubsegment("Subsegment1", custom_time);
 
             Subsegment subsegment = (Subsegment)recorder.TraceContext.GetEntity();
-            Assert.AreEqual(TimeStamp.ToUnixSeconds(custom_time), subsegment.StartTime);
+            Assert.AreEqual(1563062400, subsegment.StartTime);
 
             recorder.EndSubsegment();
             recorder.EndSegment();
@@ -1077,7 +1077,7 @@ namespace Amazon.XRay.Recorder.UnitTests
             Subsegment subsegment = (Subsegment)recorder.TraceContext.GetEntity();
             var custom_time = new DateTime(2019, 07, 14);
             recorder.EndSubsegment(custom_time);
-            Assert.AreEqual(TimeStamp.ToUnixSeconds(custom_time), subsegment.EndTime);
+            Assert.AreEqual(1563062400, subsegment.EndTime);
             recorder.EndSegment();
         }
 

--- a/sdk/test/UnitTests/AWSXRayRecorderTests.cs
+++ b/sdk/test/UnitTests/AWSXRayRecorderTests.cs
@@ -1052,6 +1052,35 @@ namespace Amazon.XRay.Recorder.UnitTests
             Assert.ThrowsException<ArgumentException>(() => new AWSXRayRecorderBuilder().WithStreamingStrategy(new DefaultStreamingStrategy(-100)));
         }
 
+        [TestMethod]
+        public void TestBeginSubsegmentWithCustomTime()
+        {
+            AWSXRayRecorder recorder = new AWSXRayRecorderBuilder().Build();
+            recorder.BeginSegment("Segment1");
+            var custom_time = new DateTime(2019, 07, 14);
+            recorder.BeginSubsegment("Subsegment1", custom_time);
+
+            Subsegment subsegment = (Subsegment)recorder.TraceContext.GetEntity();
+            Assert.AreEqual(TimeStamp.ToUnixSeconds(custom_time), subsegment.StartTime);
+
+            recorder.EndSubsegment();
+            recorder.EndSegment();
+        }
+
+        [TestMethod]
+        public void TestEndSubsegmentWithCustomTime()
+        {
+            AWSXRayRecorder recorder = new AWSXRayRecorderBuilder().Build();
+            recorder.BeginSegment("Segment1");
+            recorder.BeginSubsegment("Subsegment1");
+
+            Subsegment subsegment = (Subsegment)recorder.TraceContext.GetEntity();
+            var custom_time = new DateTime(2019, 07, 14);
+            recorder.EndSubsegment(custom_time);
+            Assert.AreEqual(TimeStamp.ToUnixSeconds(custom_time), subsegment.EndTime);
+            recorder.EndSegment();
+        }
+
         public static AWSXRayRecorder BuildAWSXRayRecorder(ISamplingStrategy samplingStrategy = null, ISegmentEmitter segmentEmitter = null, string daemonAddress = null, ITraceContext traceContext = null)
         {
             AWSXRayRecorderBuilder builder = new AWSXRayRecorderBuilder();

--- a/sdk/test/UnitTests/AWSXRayRecorderTests.cs
+++ b/sdk/test/UnitTests/AWSXRayRecorderTests.cs
@@ -1064,6 +1064,7 @@ namespace Amazon.XRay.Recorder.UnitTests
             Assert.AreEqual(1563062400, subsegment.StartTime);
 
             recorder.EndSubsegment();
+            Assert.IsTrue(DateTime.UtcNow.ToUnixTimeSeconds() >= subsegment.EndTime);
             recorder.EndSegment();
         }
 
@@ -1075,6 +1076,8 @@ namespace Amazon.XRay.Recorder.UnitTests
             recorder.BeginSubsegment("Subsegment1");
 
             Subsegment subsegment = (Subsegment)recorder.TraceContext.GetEntity();
+            Assert.IsTrue(DateTime.UtcNow.ToUnixTimeSeconds() >= subsegment.StartTime);
+
             var custom_time = new DateTime(2019, 07, 14);
             recorder.EndSubsegment(custom_time);
             Assert.AreEqual(1563062400, subsegment.EndTime);

--- a/sdk/test/UnitTests/TestLambdaContext.cs
+++ b/sdk/test/UnitTests/TestLambdaContext.cs
@@ -21,6 +21,7 @@ using Amazon.XRay.Recorder.Core.Internal.Entities;
 using Amazon.XRay.Recorder.Core.Exceptions;
 using Amazon.XRay.Recorder.Core.Sampling;
 using Amazon.XRay.Recorder.Core.Internal.Context;
+using Amazon.XRay.Recorder.Core.Internal.Utils;
 
 namespace Amazon.XRay.Recorder.UnitTests
 {
@@ -183,6 +184,35 @@ namespace Amazon.XRay.Recorder.UnitTests
             _recorder.EndSubsegment();
 
             Assert.IsFalse(AWSXRayRecorder.Instance.TraceContext.IsEntityPresent());
+        }
+
+        [TestMethod]
+        public void TestBeginSubsegmentWithCustomTime()
+        {
+            AWSXRayRecorder recorder = new AWSXRayRecorderBuilder().Build();
+            
+            var custom_time = new DateTime(2019, 07, 14);
+            recorder.BeginSubsegment("Subsegment1", custom_time);
+
+            Subsegment subsegment = (Subsegment)recorder.TraceContext.GetEntity();
+            Assert.AreEqual(1563062400, subsegment.StartTime);
+
+            recorder.EndSubsegment();
+            Assert.IsTrue(DateTime.UtcNow.ToUnixTimeSeconds() >= subsegment.EndTime);
+        }
+
+        [TestMethod]
+        public void TestEndSubsegmentWithCustomTime()
+        {
+            AWSXRayRecorder recorder = new AWSXRayRecorderBuilder().Build();
+            recorder.BeginSubsegment("Subsegment1");
+
+            Subsegment subsegment = (Subsegment)recorder.TraceContext.GetEntity();
+            Assert.IsTrue(DateTime.UtcNow.ToUnixTimeSeconds() >= subsegment.StartTime);
+
+            var custom_time = new DateTime(2019, 07, 14);
+            recorder.EndSubsegment(custom_time);
+            Assert.AreEqual(1563062400, subsegment.EndTime);
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:* [76](https://github.com/aws/aws-xray-sdk-dotnet/issues/76)

*Description of changes:*
Added timestamp parameter to BeginSubsegment and EndSubsegment.
Added Unit tests for the same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
