### PR TITLE
Validate userid for trusted connections

### DIFF
--- a/sdk/src/Handlers/SqlServer/DbCommandInterceptor.cs
+++ b/sdk/src/Handlers/SqlServer/DbCommandInterceptor.cs
@@ -128,7 +128,12 @@ namespace Amazon.XRay.Recorder.Handlers.SqlServer
             // Remove sensitive information from connection string
             connectionStringBuilder.Remove("Password");
 
-            _recorder.AddSqlInformation("user", connectionStringBuilder.UserID);
+            // Do a pre-check for UserID since in the case of TrustedConnection, a UserID may not be available.
+            if (!string.IsNullOrEmpty(connectionStringBuilder.UserID))
+            {
+                _recorder.AddSqlInformation("user", connectionStringBuilder.UserID);
+            }
+            
             _recorder.AddSqlInformation("connection_string", connectionStringBuilder.ToString());
 
             if(ShouldCollectSqlText()) 


### PR DESCRIPTION
*Issue #, if available:* [81](https://github.com/aws/aws-xray-sdk-dotnet/issues/81)

*Description of changes:*
Added validation for UserID being null or empty string.
Added unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
