### PR TITLE
Create a SamplingInput with only ServiceName

### DIFF
--- a/sdk/src/Core/AWSXRayRecorderImpl.cs
+++ b/sdk/src/Core/AWSXRayRecorderImpl.cs
@@ -160,7 +160,7 @@ namespace Amazon.XRay.Recorder.Core
 
             if (samplingResponse == null)
             {
-                SamplingInput samplingInput = new SamplingInput();
+                SamplingInput samplingInput = new SamplingInput(name);
                 samplingResponse = SamplingStrategy.ShouldTrace(samplingInput);
             }
 

--- a/sdk/src/Core/Sampling/SamplingInput.cs
+++ b/sdk/src/Core/Sampling/SamplingInput.cs
@@ -26,6 +26,11 @@ namespace Amazon.XRay.Recorder.Core.Sampling
         {
         }
 
+        public SamplingInput(string serviceName)
+        {
+            ServiceName = serviceName;
+        }
+
         public SamplingInput(string host, string url, string method, string serviceName, string serviceType)
         {
             Host = host;

--- a/sdk/test/UnitTests/RuleCacheTests.cs
+++ b/sdk/test/UnitTests/RuleCacheTests.cs
@@ -213,12 +213,46 @@ namespace Amazon.XRay.Recorder.UnitTests
         }
 
         [TestMethod]
+        public void TestGetMatchedRule4() // sampling input has only ServiceName - the rule should be matched 
+        {
+            RuleCache ruleCache = new RuleCache();
+            List<SamplingRule> newRules = new List<SamplingRule>();
+            SamplingInput samplingInput = new SamplingInput("elasticbeanstalk");
+            SamplingRule expectedRule = GetSamplingRule("a", 1, 0.5, 10, serviceName: samplingInput.ServiceName);
+            newRules.Add(expectedRule);
+            ruleCache.LoadRules(newRules);
+            TimeStamp current = TimeStamp.CurrentTime();
+            ruleCache.LastUpdated = current;
+
+            var actualRule = ruleCache.GetMatchedRule(samplingInput, current);
+
+            Assert.IsTrue(actualRule.Equals(expectedRule));
+        }
+
+        [TestMethod]
         public void TestGetMatchedRuleNotMatching() // Rule not matched
         {
             RuleCache ruleCache = new RuleCache();
             List<SamplingRule> newRules = new List<SamplingRule>();
             SamplingInput samplingInput = new SamplingInput("elasticbeanstalk", "/api/1", "GET", "dynamo", "*");
             SamplingRule rule = GetSamplingRule("a", 1, 0.5, 10, "j", samplingInput.ServiceName, samplingInput.Method, samplingInput.Url);
+            newRules.Add(rule);
+            ruleCache.LoadRules(newRules);
+            TimeStamp current = TimeStamp.CurrentTime();
+            ruleCache.LastUpdated = current;
+
+            var actualRule = ruleCache.GetMatchedRule(samplingInput, current);
+
+            Assert.IsNull(actualRule);
+        }
+
+        [TestMethod]
+        public void TestGetMatchedRuleNotMatching2() // SamplingInput with only ServiceName - Rule not matched
+        {
+            RuleCache ruleCache = new RuleCache();
+            List<SamplingRule> newRules = new List<SamplingRule>();
+            SamplingInput samplingInput = new SamplingInput("elasticbeanstalk");
+            SamplingRule rule = GetSamplingRule("a", 1, 0.5, 10, serviceName: "XYZ");
             newRules.Add(rule);
             ruleCache.LoadRules(newRules);
             TimeStamp current = TimeStamp.CurrentTime();
@@ -238,6 +272,25 @@ namespace Amazon.XRay.Recorder.UnitTests
             SamplingRule rule = GetSamplingRule("a", 1, 0.5, 10, "j", "test", samplingInput.Method, samplingInput.Url);
             newRules.Add(rule);
             SamplingRule expectedRule = GetSamplingRule(SamplingRule.Default, 10000, 0.5, 1, "j", "*", "*","*"); // should match to default rule
+            newRules.Add(expectedRule);
+            ruleCache.LoadRules(newRules);
+            TimeStamp current = TimeStamp.CurrentTime();
+            ruleCache.LastUpdated = current;
+
+            var actualRule = ruleCache.GetMatchedRule(samplingInput, current);
+
+            Assert.IsTrue(actualRule.Equals(expectedRule));
+        }
+
+        [TestMethod]
+        public void TestGetMatchedRuleWithDefaultRule2() // SamplingInput with only ServiceName - Matching with default Rule;
+        {
+            RuleCache ruleCache = new RuleCache();
+            List<SamplingRule> newRules = new List<SamplingRule>();
+            SamplingInput samplingInput = new SamplingInput("elasticbeanstalk");
+            SamplingRule rule = GetSamplingRule("a", 1, 0.5, 10, serviceName: "XYZ");
+            newRules.Add(rule);
+            SamplingRule expectedRule = GetSamplingRule(SamplingRule.Default, 10000, 0.5, 1, "j", "*", "*", "*"); // should match to default rule
             newRules.Add(expectedRule);
             ruleCache.LoadRules(newRules);
             TimeStamp current = TimeStamp.CurrentTime();


### PR DESCRIPTION
Adding a constructor for SamplingInput with ServiceName to fix the issue where SamplingInput was created with ServiceName as null and would match the first rule in centralized sampling for manually created Segments using BeginSegment.

*Issue #, if available:* [99](https://github.com/aws/aws-xray-sdk-dotnet/issues/99)

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
