### PR TITLE
Use ID of subsegment created for SDK request in trace header.

### DIFF
--- a/sdk/src/Handlers/AwsSdk/Internal/XRayPipelineHandler.cs
+++ b/sdk/src/Handlers/AwsSdk/Internal/XRayPipelineHandler.cs
@@ -319,6 +319,11 @@ namespace Amazon.XRay.Recorder.Handlers.AwsSdk.Internal
                 _recorder.TraceContext.HandleEntityMissing(_recorder, e, "Cannot get entity while processing AWS SDK request");
             }
 
+            _recorder.BeginSubsegment(RemoveAmazonPrefixFromServiceName(request.ServiceName));
+            _recorder.SetNamespace("aws");
+
+            entity = entity == null ? null : _recorder.GetEntity();
+
             if (TraceHeader.TryParse(entity, out TraceHeader traceHeader))
             {
                 request.Headers[TraceHeader.HeaderKey] = traceHeader.ToString();
@@ -327,9 +332,6 @@ namespace Amazon.XRay.Recorder.Handlers.AwsSdk.Internal
             {
                 _logger.DebugFormat("Failed to inject trace header to AWS SDK request as the segment can't be converted to TraceHeader.");
             }
-
-            _recorder.BeginSubsegment(RemoveAmazonPrefixFromServiceName(request.ServiceName));
-            _recorder.SetNamespace("aws");
         }
 
         /// <summary>


### PR DESCRIPTION
*Issue #104 *

*Description of changes:*

Crate the XRay subsegment for the AWS SDK request before creating the trace header.  This will allow the ID of the subsegment to be used as the `ParentId` in the trace header.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
