### PR TITLE
Whitelisting EndpointName parameter SageMakerRuntime

### DIFF
--- a/sdk/src/Handlers/AwsSdk/DefaultAWSWhitelist.json
+++ b/sdk/src/Handlers/AwsSdk/DefaultAWSWhitelist.json
@@ -71,6 +71,7 @@
 //   Route53
 //   Route53Domains
 //   S3
+//   SageMaker
 //   SecurityToken
 //   ServerMigrationService
 //   ServiceCatalog
@@ -425,7 +426,7 @@
             }
         }
      },
-      "S3": {
+    "S3": {
       "operations": {
         "CopyObject": {
           "request_parameters": [
@@ -827,6 +828,15 @@
           ]
         }
       }
-    }
+    },
+	"SageMakerRuntime": {
+		"operations": {
+			"InvokeEndpoint": {
+				"request_parameters": [
+					"EndpointName"
+				]
+			}
+		}
+	}
   }
 }


### PR DESCRIPTION
Whitelisting "EndpointName" parameter for "InvokeEndpoint" operation of SageMakerRuntime service.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
