### PR TITLE
Don't floor custom start/end timestamps.

### DIFF
--- a/sdk/src/Core/Internal/Entities/Entity.cs
+++ b/sdk/src/Core/Internal/Entities/Entity.cs
@@ -422,7 +422,7 @@ namespace Amazon.XRay.Recorder.Core.Internal.Entities
         /// </summary>
         public void SetStartTime(DateTime timestamp)
         {
-            StartTime = TimeStamp.ToUnixSeconds(timestamp);
+            StartTime = timestamp.ToUnixTimeSeconds();
         }
 
         /// <summary>
@@ -430,7 +430,7 @@ namespace Amazon.XRay.Recorder.Core.Internal.Entities
         /// </summary>
         public void SetEndTime(DateTime timestamp)
         {
-            EndTime = TimeStamp.ToUnixSeconds(timestamp);
+            EndTime = timestamp.ToUnixTimeSeconds();
         }
 
         /// <summary>

--- a/sdk/src/Core/Sampling/TimeStamp.cs
+++ b/sdk/src/Core/Sampling/TimeStamp.cs
@@ -63,15 +63,6 @@ namespace Amazon.XRay.Recorder.Core.Sampling
             return DateTime.UtcNow;
         }
 
-        /// <summary>
-        /// Converts <see cref="DateTime"/> to unix seconds.
-        /// </summary>
-        /// <param name="time">Instance of <see cref="DateTime"/>.</param>
-        /// <returns>unix seconds.</returns>
-        internal static decimal ToUnixSeconds(DateTime time)
-        {
-            return GetUnixSeconds(time);
-        }
         internal bool IsGreaterThan(TimeStamp timeStamp)
         {
             return Time > timeStamp.Time;

--- a/sdk/test/UnitTests/AWSXRayRecorderTests.cs
+++ b/sdk/test/UnitTests/AWSXRayRecorderTests.cs
@@ -1053,6 +1053,19 @@ namespace Amazon.XRay.Recorder.UnitTests
         }
 
         [TestMethod]
+        public void TestBeginSegmentWithCustomTime()
+        {
+            var custom_time = new DateTime(2020, 1, 13, 21, 18, 47, 228, DateTimeKind.Utc);
+            AWSXRayRecorder recorder = new AWSXRayRecorderBuilder().Build();
+            recorder.BeginSegment("Segment1", timestamp: custom_time);
+
+            Segment segment = (Segment)recorder.TraceContext.GetEntity();
+            Assert.AreEqual(1578950327.228m, segment.StartTime);
+
+            recorder.EndSegment();
+        }
+
+        [TestMethod]
         public void TestBeginSubsegmentWithCustomTime()
         {
             AWSXRayRecorder recorder = new AWSXRayRecorderBuilder().Build();

--- a/sdk/test/UnitTests/UtilsTests.cs
+++ b/sdk/test/UnitTests/UtilsTests.cs
@@ -38,6 +38,9 @@ namespace Amazon.XRay.Recorder.UnitTests
 
             DateTime time1 = new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             Assert.AreEqual(time1.ToUnixTimeSeconds(), 1451606400m);
+
+            DateTime time2 = new DateTime(2020, 1, 13, 21, 18, 47, 228, DateTimeKind.Utc);
+            Assert.AreEqual(time2.ToUnixTimeSeconds(), 1578950327.228m);
         }
 
         [TestMethod]


### PR DESCRIPTION
*Issue #, if available:*
#118 

*Description of changes:*
Removes the `decimal.Floor` operation performed on the start/end timestamps as described in the issue #118. Adds test cases to ensure precision down to 1ms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
