### PR TITLE
Add DelegateExporter to JsonSegmentMarshaller

### DIFF
--- a/sdk/src/Core/Internal/Emitters/JsonSegmentMarshaller.cs
+++ b/sdk/src/Core/Internal/Emitters/JsonSegmentMarshaller.cs
@@ -15,6 +15,7 @@
 // </copyright>
 //-----------------------------------------------------------------------------
 
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
@@ -44,6 +45,7 @@ namespace Amazon.XRay.Recorder.Core.Internal.Emitters
             JsonMapper.RegisterExporter<Annotations>(AnnotationsExporter);
             JsonMapper.RegisterExporter<HttpMethod>(HttpMethodExporter);
             JsonMapper.RegisterExporter<ConstantClass>(ConstantClassExporter);
+            JsonMapper.RegisterExporter<Delegate>(DelegateExporter);
         }
 
         /// <summary>
@@ -323,6 +325,13 @@ namespace Amazon.XRay.Recorder.Core.Internal.Emitters
         private static void ConstantClassExporter(ConstantClass constantClass, JsonWriter writer)
         {
             writer.Write(constantClass.Value);
+        }
+
+        private static void DelegateExporter(Delegate method, JsonWriter writer)
+        {
+            var methodInfo = method.Method;
+            var str = $"{methodInfo.ReflectedType.Name}.{methodInfo.Name}({method})";
+            writer.Write(str);
         }
     }
 }


### PR DESCRIPTION
If object type is Delegate, `JsonMapper.WriteValue` will try to write it as an object, and calls itself with the same input which results in `JsonException("Max allowed object depth reached...")`

*Issue #, if available:* #109 (similar)

*Description of changes:* Added an exporter to `JsonSegmentMarshaller` that would write a delegate as: <class>.<function name>(<function type>)
e.g. ``"JsonSegmentMarshallerTest.SyncFunction(System.Func`2[System.Object,System.Object])"``


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
