### PR TITLE
Added support for tracing SQL query through Entity Framework Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,25 +395,24 @@ For how to start with Entity Framework Core in an ASP.NET Core web app, please t
 
 #### Setup
 
-In order to trace SQL query, you can register your `DbContext` with `EFInterceptor` in the `ConfigureServices` method in `startup.cs` file. 
+In order to trace SQL query, you can register your `DbContext` with `AddXRayInterceptor()` accordingly in the `ConfigureServices` method in `startup.cs` file. 
 
 For instance, when dealing with MySql server using Nuget: [Pomelo.EntityFrameworkCore.MySql](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql) (V 3.1.1). 
 
 ```csharp
-public void ConfigureServices(IServiceCollection services){ 
-
-    services.AddDbContext<your_DbContext>(options => options.UseMySql(your_connectionString).AddInterceptors(new EFInterceptor()));
-
+public void ConfigureServices(IServiceCollection services)
+{ 
+    services.AddDbContext<your_DbContext>(options => options.UseMySql(your_connectionString).AddXRayInterceptor());
 }
 ```
 
-Alternatively, you can register `EFInterceptor` in the `Onconfiguring` method in your `DbContext` class. Below we are using Nuget: [Microsoft.EntityFrameworkCore.Sqlite](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Sqlite) (V 3.1.2)
+Alternatively, you can register `AddXRayInterceptor()` in the `Onconfiguring` method in your `DbContext` class. Below we are using Nuget: [Microsoft.EntityFrameworkCore.Sqlite](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Sqlite) (V 3.1.2)
 
 ```csharp
 public class your_DbContext : DbContext 
 {
 	protected override void OnConfiguring(DbContextOptionsBuilder options)
-    => options.UseSqlite(your_connectionString).AddInterceptors(new EFInterceptor());
+    => options.UseSqlite(your_connectionString).AddXRayInterceptor();
 }
 ```
 
@@ -433,13 +432,12 @@ If you want to enable this feature, it can be done in two ways. First, by settin
 }
 ```
 
-Secondly, you can set the `collectSqlQueries` parameter in the `EFInterceptor` instance as **true** to collect the SQL query text. If you set this parameter as **false**, it will disable the `collectSqlQueries` feature for this `EFInterceptor` instance.
+Secondly, you can set the `collectSqlQueries` parameter in the `AddXRayInterceptor()` as **true** to collect the SQL query text. If you set this parameter as **false**, it will disable the `collectSqlQueries` feature for this `AddXRayInterceptor()`.
 
 ```csharp
-public void ConfigureServices(IServiceCollection services){
-
-    services.AddDbContext<your_DbContext>(options => options.UseMySql(your_connectionString).AddInterceptors(new EFInterceptor(true)));
-
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddDbContext<your_DbContext>(options => options.UseMySql(your_connectionString).AddXRayInterceptor(true));
 }
 ```
 
@@ -449,7 +447,7 @@ Or
 public class your_DbContext : DbContext 
 {
 	protected override void OnConfiguring(DbContextOptionsBuilder options)
-    => options.UseSqlite(your_connectionString).AddInterceptors(new EFInterceptor(true));
+    => options.UseSqlite(your_connectionString).AddXRayInterceptor(true);
 }
 ```
  

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ using (var command = new TraceableSqlCommand("SELECT * FROM products", connectio
 
 AWS XRay SDK for .NET Core provides interceptor for tracing SQL query through Entity Framework Core (>=3.0).
 
-For how to start with Entity Framework Core in an ASP.NET Core web app, please take reference to [Link](https://docs.microsoft.com/en-us/aspnet/core/data/ef-rp/intro?view=aspnetcore-3.1&tabs=visual-studio)
+For how to start with Entity Framework Core in an ASP.NET Core web app, please take reference to [Link](https://docs.microsoft.com/en-us/aspnet/core/data/ef-mvc/?view=aspnetcore-3.1)
 
 *NOTE:*
 

--- a/README.md
+++ b/README.md
@@ -383,6 +383,76 @@ using (var command = new TraceableSqlCommand("SELECT * FROM products", connectio
 2. Parameterized values will appear in their tokenized form and will not be expanded.
 3. The value of `collectSqlQueries` in the `TraceableSqlCommand` instance overrides the value set in the global configuration using the `CollectSqlQueries` property.
 
+### Trace SQL Query through Entity Framework Core 3.0 and above (.NET Core)
+
+AWS XRay SDK for .NET Core provides interceptor for tracing SQL query through Entity Framework Core (>=3.0).
+
+For how to start with Entity Framework Core in an ASP.NET Core web app, please take reference to [Link](https://docs.microsoft.com/en-us/aspnet/core/data/ef-rp/intro?view=aspnetcore-3.1&tabs=visual-studio)
+
+*NOTE:*
+
+* Not all database provider support Entity Framework Core 3.0 and above, please make sure that you are using the [Nuget package](https://docs.microsoft.com/en-us/ef/core/providers/?tabs=dotnet-core-cli) with a compatible version (EF Core >= 3.0).
+
+#### Setup
+
+In order to trace SQL query, you can register your `DbContext` with `EFInterceptor` in the `ConfigureServices` method in `startup.cs` file. 
+
+For instance, when dealing with MySql server using Nuget: [Pomelo.EntityFrameworkCore.MySql](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql) (V 3.1.1). 
+
+```csharp
+public void ConfigureServices(IServiceCollection services){ 
+
+    services.AddDbContext<your_DbContext>(options => options.UseMySql(your_connectionString).AddInterceptors(new EFInterceptor()));
+
+}
+```
+
+Alternatively, you can register `EFInterceptor` in the `Onconfiguring` method in your `DbContext` class. Below we are using Nuget: [Microsoft.EntityFrameworkCore.Sqlite](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Sqlite) (V 3.1.2)
+
+```csharp
+public class your_DbContext : DbContext 
+{
+	protected override void OnConfiguring(DbContextOptionsBuilder options)
+    => options.UseSqlite(your_connectionString).AddInterceptors(new EFInterceptor());
+}
+```
+
+The connection string can be either hard coded or configured from `appsettings.json` file.
+
+#### Capture SQL Query text in the traced SQL calls to SQL Server
+
+You can also opt in to capture the `DbCommand.CommandText` as part of the subsegment created for your SQL query. The collected `DbCommand.CommandText` will appear as `sanitized_query` in the subsegment JSON. By default, this feature is disabled due to security reasons. 
+
+If you want to enable this feature, it can be done in two ways. First, by setting the `CollectSqlQueries` to **true** in the `appsettings.json` file as follows:
+
+```json
+{
+  "XRay": {
+    "CollectSqlQueries":"true"
+  }
+}
+```
+
+Secondly, you can set the `collectSqlQueries` parameter in the `EFInterceptor` instance as **true** to collect the SQL query text. If you set this parameter as **false**, it will disable the `collectSqlQueries` feature for this `EFInterceptor` instance.
+
+```csharp
+public void ConfigureServices(IServiceCollection services){
+
+    services.AddDbContext<your_DbContext>(options => options.UseMySql(your_connectionString).AddInterceptors(new EFInterceptor(true)));
+
+}
+```
+
+Or
+
+```csharp
+public class your_DbContext : DbContext 
+{
+	protected override void OnConfiguring(DbContextOptionsBuilder options)
+    => options.UseSqlite(your_connectionString).AddInterceptors(new EFInterceptor(true));
+}
+```
+ 
 ### Multithreaded Execution (.NET and .NET Core) : [Nuget](https://www.nuget.org/packages/AWSXRayRecorder.Core/)
 
 In multithreaded execution, X-Ray context from current to its child thread is automatically set.  

--- a/sdk/AWSXRayRecorder.sln
+++ b/sdk/AWSXRayRecorder.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSXRayRecorder.UnitTests",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSXRayRecorder.Handlers.AspNet", "src\Handlers\AspNet\AWSXRayRecorder.Handlers.AspNet.csproj", "{C647F311-4023-4E0B-9147-074EAF243D54}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWSXRayRecorder.Handlers.EntityFramework", "src\Handlers\EntityFramework\AWSXRayRecorder.Handlers.EntityFramework.csproj", "{5F34AA28-E5DF-4699-BB14-100BA109F6BF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -80,6 +82,12 @@ Global
 		{C647F311-4023-4E0B-9147-074EAF243D54}.Nuget|Any CPU.Build.0 = Release|Any CPU
 		{C647F311-4023-4E0B-9147-074EAF243D54}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C647F311-4023-4E0B-9147-074EAF243D54}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F34AA28-E5DF-4699-BB14-100BA109F6BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F34AA28-E5DF-4699-BB14-100BA109F6BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F34AA28-E5DF-4699-BB14-100BA109F6BF}.Nuget|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F34AA28-E5DF-4699-BB14-100BA109F6BF}.Nuget|Any CPU.Build.0 = Debug|Any CPU
+		{5F34AA28-E5DF-4699-BB14-100BA109F6BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F34AA28-E5DF-4699-BB14-100BA109F6BF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -93,6 +101,7 @@ Global
 		{7E2D2EC0-DFA6-4B4D-B79F-EBC08CCD2A8A} = {6FD9C919-1504-445D-B70D-D0F8AC2829C4}
 		{B7D60B1F-C452-454E-AD4B-202A40E628E8} = {F0ED74B6-1639-47D3-9511-B4217012AC88}
 		{C647F311-4023-4E0B-9147-074EAF243D54} = {6FD9C919-1504-445D-B70D-D0F8AC2829C4}
+		{5F34AA28-E5DF-4699-BB14-100BA109F6BF} = {6FD9C919-1504-445D-B70D-D0F8AC2829C4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E3276CD5-62B3-466D-BFDD-2AFDB8819B46}

--- a/sdk/src/Handlers/EntityFramework/AWSXRayInterceptorExtensions.cs
+++ b/sdk/src/Handlers/EntityFramework/AWSXRayInterceptorExtensions.cs
@@ -1,0 +1,40 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="TraceableSqlCommand.net45.cs" company="Amazon.com">
+//      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+//      Licensed under the Apache License, Version 2.0 (the "License").
+//      You may not use this file except in compliance with the License.
+//      A copy of the License is located at
+//
+//      http://aws.amazon.com/apache2.0
+//
+//      or in the "license" file accompanying this file. This file is distributed
+//      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//      express or implied. See the License for the specific language governing
+//      permissions and limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Amazon.XRay.Recorder.Handlers.EntityFramework
+{
+    /// <summary>
+    /// Extension method for <see cref="DbContextOptionsBuilder"/> to add <see cref="EFInterceptor"/>.
+    /// User can pass collectSqlQueries to AddXRayInterceptor() to decide if sanitized_query should be included in the trace
+    /// context or not.
+    /// </summary>
+    public static class AWSXRayInterceptorExtensions
+    {
+        /// <summary>
+        /// Add <see cref="EFInterceptor"/> to <see cref="DbContextOptionsBuilder"/>.
+        /// </summary>
+        /// <param name="dbContextOptionsBuilder">Instance of <see cref="DbContextOptionsBuilder"/>.</param>
+        /// <param name="collectSqlQueries"></param>
+        /// <returns>Instance of <see cref="DbContextOptionsBuilder"/>.</returns>
+        public static DbContextOptionsBuilder AddXRayInterceptor(this DbContextOptionsBuilder dbContextOptionsBuilder, bool? collectSqlQueries = null)
+        {
+            return dbContextOptionsBuilder.AddInterceptors(new EFInterceptor(collectSqlQueries));
+        }
+    }
+}

--- a/sdk/src/Handlers/EntityFramework/AWSXRayInterceptorExtensions.cs
+++ b/sdk/src/Handlers/EntityFramework/AWSXRayInterceptorExtensions.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------------
-// <copyright file="TraceableSqlCommand.net45.cs" company="Amazon.com">
+// <copyright file="AWSXRayInterceptorExtensions.cs" company="Amazon.com">
 //      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 //      Licensed under the Apache License, Version 2.0 (the "License").

--- a/sdk/src/Handlers/EntityFramework/AWSXRayRecorder.Handlers.EntityFramework.csproj
+++ b/sdk/src/Handlers/EntityFramework/AWSXRayRecorder.Handlers.EntityFramework.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Company>Amazon.com, Inc</Company>
+    <Product>Amazon Web Service X-Ray Recorder</Product>
+    <Copyright>Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
+    <AssemblyName>AWSXRayRecorder.Handlers.EntityFramework</AssemblyName>
+    <RootNamespace>Amazon.XRay.Recorder.Handlers.EntityFramework</RootNamespace>
+    <Authors>Amazon Web Services</Authors>
+    <Description>This package contains libraries to trace SQL queries through Entity Framework Core.</Description>
+    <PackageLicenseUrl>http://aws.amazon.com/apache2.0/</PackageLicenseUrl>
+    <PackageProjectUrl>https://aws.amazon.com/documentation/xray/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/aws/aws-xray-sdk-dotnet</RepositoryUrl>
+    <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>
+    <PackageTags>AWS Amazon cloud AWSXRay XRay</PackageTags>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../../../../buildtools/local-development.snk</AssemblyOriginatorKeyFile>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591;</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\AWSXRayRecorder.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/src/Handlers/EntityFramework/AWSXRayRecorder.Handlers.EntityFramework.csproj
+++ b/sdk/src/Handlers/EntityFramework/AWSXRayRecorder.Handlers.EntityFramework.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
-    <Copyright>Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
+    <Copyright>Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <AssemblyName>AWSXRayRecorder.Handlers.EntityFramework</AssemblyName>
     <RootNamespace>Amazon.XRay.Recorder.Handlers.EntityFramework</RootNamespace>
     <Authors>Amazon Web Services</Authors>
@@ -24,7 +24,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
   </ItemGroup>
 

--- a/sdk/src/Handlers/EntityFramework/EFInterceptor.cs
+++ b/sdk/src/Handlers/EntityFramework/EFInterceptor.cs
@@ -1,0 +1,389 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="TraceableSqlCommand.net45.cs" company="Amazon.com">
+//      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+//      Licensed under the Apache License, Version 2.0 (the "License").
+//      You may not use this file except in compliance with the License.
+//      A copy of the License is located at
+//
+//      http://aws.amazon.com/apache2.0
+//
+//      or in the "license" file accompanying this file. This file is distributed
+//      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//      express or implied. See the License for the specific language governing
+//      permissions and limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Amazon.XRay.Recorder.Core;
+using Amazon.XRay.Recorder.Core.Internal.Entities;
+using Amazon.XRay.Recorder.Core.Exceptions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Amazon.XRay.Recorder.Handlers.EntityFramework
+{
+    public class EFInterceptor : DbCommandInterceptor
+    {
+        // Some database providers may not support Entity Framework Core 3.0 and above now
+        // https://docs.microsoft.com/en-us/ef/core/providers/?tabs=dotnet-core-cli
+        private readonly string[] DatabaseTypes = { "mysql" , "sqlserver" , "sqlite" , "postgresql" , "firebird" , "cosmos" ,
+                                                    "oracle" , "filecontextcore" , "jet" , "teradata" , "openedge" , "ibm" ,
+                                                    "mycat" , "inmemory" };
+
+        private const string SqlServerCompact35 = "sqlservercompact35";
+        private const string SqlServerCompact40 = "sqlservercompact40";
+        private const string DefaultDatabaseType = "EntityFrameworkCore";
+        private readonly AWSXRayRecorder _recorder;
+        private readonly bool? _collectSqlQueriesOverride;
+
+        public EFInterceptor() : this(AWSXRayRecorder.Instance)
+        {
+
+        }
+
+        public EFInterceptor(bool? collectSqlQueries = null) : this(AWSXRayRecorder.Instance, collectSqlQueries)
+        {
+
+        }
+
+        public EFInterceptor(AWSXRayRecorder recorder, bool? collectSqlQueries = null) : base()
+        {
+            _recorder = recorder;
+            _collectSqlQueriesOverride = collectSqlQueries;
+        }
+
+        /// <summary>
+        /// Trace before executing reader.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandEventData"/>.</param>
+        /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
+        /// <returns>Result from <see cref="IInterceptor"/>.</returns>
+        public override InterceptionResult<DbDataReader> ReaderExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            ProcessBeginCommand(eventData);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        /// <summary>
+        /// Trace after executing reader.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandExecutedEventData"/>.</param>
+        /// <param name="result">Instance of <see cref="DbDataReader"/>.</param>
+        /// <returns>Instance of <see cref="DbDataReader"/>.</returns>
+        public override DbDataReader ReaderExecuted(DbCommand command, CommandExecutedEventData eventData, DbDataReader result)
+        {
+            ProcessEndCommand();
+            return base.ReaderExecuted(command, eventData, result);
+        }
+
+        /// <summary>
+        /// Trace before executing reader asynchronously.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandEventData"/>.</param>
+        /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
+        /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>Task representing the async operation.</returns>
+        public override Task<InterceptionResult<DbDataReader>> ReaderExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result, CancellationToken cancellationToken = default)
+        {
+            ProcessBeginCommand(eventData);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        /// <summary>
+        /// Trace after executing reader asynchronously.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandExecutedEventData"/>.</param>
+        /// <param name="result">Result from <see cref="DbDataReader"/>.</param>
+        /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>Task representing the async operation.</returns>
+        public override Task<DbDataReader> ReaderExecutedAsync(DbCommand command, CommandExecutedEventData eventData, DbDataReader result, CancellationToken cancellationToken = default)
+        {
+            ProcessEndCommand();
+            return base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
+        }
+
+        /// <summary>
+        /// Trace after command fails.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandErrorEventData"/>.</param>
+        public override void CommandFailed(DbCommand command, CommandErrorEventData eventData)
+        {
+            ProcessCommandError(eventData);
+            base.CommandFailed(command, eventData);
+        }
+
+        /// <summary>
+        /// Trace after async command fails.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandErrorEventData"/>.</param>
+        /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>Task representing the async operation.</returns>
+        public override Task CommandFailedAsync(DbCommand command, CommandErrorEventData eventData, CancellationToken cancellationToken = default)
+        {
+            ProcessCommandError(eventData);
+            return base.CommandFailedAsync(command, eventData, cancellationToken);
+        }
+
+        /// <summary>
+        /// Trace before excuting.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandEventData"/>.</param>
+        /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
+        /// <returns>Task representing the operation.</returns>
+        public override InterceptionResult<int> NonQueryExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
+        {
+            ProcessBeginCommand(eventData);
+            return base.NonQueryExecuting(command, eventData, result);
+        }
+
+        /// <summary>
+        /// Trace before executing asynchronously.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandEventData"/>.</param>
+        /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
+        /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>Task representing the async operation.</returns>
+        public override Task<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+        {
+            ProcessBeginCommand(eventData);
+            return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        /// <summary>
+        /// Trace after executing.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandExecutedEventData"/>.</param>
+        /// <param name="result">Result as integer.</param>
+        /// <returns>Result as integer.</returns>
+        public override int NonQueryExecuted(DbCommand command, CommandExecutedEventData eventData, int result)
+        {
+            ProcessEndCommand();
+            return base.NonQueryExecuted(command, eventData, result);
+        }
+
+        /// <summary>
+        /// Trace after executing asynchronously.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandExecutedEventData"/>.</param>
+        /// <param name="result">Result as integer.</param>
+        /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>Task representing the async operation.</returns>
+        public override Task<int> NonQueryExecutedAsync(DbCommand command, CommandExecutedEventData eventData, int result, CancellationToken cancellationToken = default)
+        {
+            ProcessEndCommand();
+            return base.NonQueryExecutedAsync(command, eventData, result, cancellationToken);
+        }
+
+        /// <summary>
+        /// Trace before executing scalar.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandEventData"/>.</param>
+        /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
+        /// <returns>Result from <see cref="IInterceptor"/>.</returns>
+        public override InterceptionResult<object> ScalarExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<object> result)
+        {
+            ProcessBeginCommand(eventData);
+            return base.ScalarExecuting(command, eventData, result);
+        }
+
+        /// <summary>
+        /// Trace before executing scalar asynchronously.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandEventData"/>.</param>
+        /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
+        /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>Task representing the async operation.</returns>
+        public override Task<InterceptionResult<object>> ScalarExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<object> result, CancellationToken cancellationToken = default)
+        {
+            ProcessBeginCommand(eventData);
+            return base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        /// <summary>
+        /// Trace after executing scalar.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandExecutedEventData"/>.</param>
+        /// <param name="result">Result object.</param>
+        /// <returns>Result object.</returns>
+        public override object ScalarExecuted(DbCommand command, CommandExecutedEventData eventData, object result)
+        {
+            ProcessEndCommand();
+            return base.ScalarExecuted(command, eventData, result);
+        }
+
+        /// <summary>
+        /// Trace after executing scalar asynchronously.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandExecutedEventData"/>.</param>
+        /// <param name="result">Result object.</param>
+        /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>Task representing the async operation.</returns>
+        public override Task<object> ScalarExecutedAsync(DbCommand command, CommandExecutedEventData eventData, object result, CancellationToken cancellationToken = default)
+        {
+            ProcessEndCommand();
+            return base.ScalarExecutedAsync(command, eventData, result, cancellationToken);
+        }
+
+        private void ProcessBeginCommand(CommandEventData eventData)
+        {
+            Entity entity = null;
+            try
+            {
+                entity = _recorder.GetEntity();
+            }
+            catch (EntityNotAvailableException e)
+            {
+                _recorder.TraceContext.HandleEntityMissing(_recorder, e, "Cannot get entity while processing start of Entity Framework command.");
+            }
+
+            _recorder.BeginSubsegment(BuildSubsegmentName(eventData.Command));
+            _recorder.SetNamespace("remote");
+            CollectSqlInformation(eventData);
+        }
+
+        private void ProcessEndCommand()
+        {
+            Entity entity = null;
+            try
+            {
+                entity = _recorder.GetEntity();
+            }
+            catch (EntityNotAvailableException e)
+            {
+                _recorder.TraceContext.HandleEntityMissing(_recorder, e, "Cannot get entity while processing end of Entity Framework command.");
+                return;
+            }
+
+            _recorder.EndSubsegment();
+        }
+
+        private void ProcessCommandError(CommandErrorEventData eventData)
+        {
+            Entity subsegment;
+            try
+            {
+                subsegment = _recorder.GetEntity();
+            }
+            catch (EntityNotAvailableException e)
+            {
+                _recorder.TraceContext.HandleEntityMissing(_recorder, e, "Cannot get entity while processing failure of Entity Framework command.");
+                return;
+            }
+
+            subsegment.AddException(eventData.Exception);
+
+            _recorder.EndSubsegment();
+        }
+
+        /// <summary>
+        /// Records the SQL information on the current subsegment,
+        /// </summary>
+        protected virtual void CollectSqlInformation(CommandEventData eventData)
+        {
+            // Get database type from DbContext
+            string databaseType = GetDataBaseType(eventData.Context);
+            _recorder.AddSqlInformation("database_type", databaseType);
+
+            _recorder.AddSqlInformation("database_version", eventData.Command.Connection.ServerVersion);
+
+            DbConnectionStringBuilder connectionStringBuilder = new DbConnectionStringBuilder();
+            connectionStringBuilder.ConnectionString = eventData.Command.Connection.ConnectionString;
+
+            // Remove sensitive information from connection string
+            connectionStringBuilder.Remove("Password");
+
+            // Do a pre-check for UserID since in the case of TrustedConnection, a UserID may not be available.
+            var user_id = GetConnectionValue(connectionStringBuilder, "User ID");
+            if (user_id != null)
+            {
+                _recorder.AddSqlInformation("user", user_id.ToString());
+            }
+
+            _recorder.AddSqlInformation("connection_string", connectionStringBuilder.ToString());
+
+            if (ShouldCollectSqlText())
+            {
+                _recorder.AddSqlInformation("sanitized_query", eventData.Command.CommandText);
+            }
+        }
+
+        private string GetDataBaseType(DbContext context)
+        {
+            string databaseProvider = context.Database?.ProviderName?.ToLower();
+
+            if (string.IsNullOrEmpty(databaseProvider))
+            {
+                return DefaultDatabaseType;
+            }
+
+            if (databaseProvider.Contains(SqlServerCompact35))
+            {
+                return SqlServerCompact35;
+            }
+            else if (databaseProvider.Contains(SqlServerCompact40))
+            {
+                return SqlServerCompact40;
+            }
+
+            string databaseType = null;
+
+            foreach (string t in DatabaseTypes)
+            {
+                if (databaseProvider.Contains(t))
+                {
+                    databaseType = t;
+                    break;
+                }
+            }
+
+            return databaseType ?? databaseProvider;
+        }
+
+        private object GetConnectionValue(DbConnectionStringBuilder builder, string key)
+        {
+            object value = null;
+            if (key == null)
+            {
+                return null;
+            }
+            builder.TryGetValue(key, out value);
+            return value;
+        }
+
+        /// <summary>
+        /// Builds the name of the subsegment in the format database@datasource
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <returns>Returns the formed subsegment name as a string.</returns>
+        private string BuildSubsegmentName(DbCommand command)
+            => command.Connection.Database + "@" + RemovePortNumberFromDataSource(command.Connection.DataSource);
+
+        private string RemovePortNumberFromDataSource(string dataSource)
+        {
+            Regex _portNumberRegex = new Regex(@",\d+$");
+            return _portNumberRegex.Replace(dataSource, string.Empty);
+        }
+
+        private bool ShouldCollectSqlText()
+            => _collectSqlQueriesOverride ?? _recorder.XRayOptions.CollectSqlQueries;
+    }
+}

--- a/sdk/src/Handlers/EntityFramework/EFUtil.cs
+++ b/sdk/src/Handlers/EntityFramework/EFUtil.cs
@@ -1,0 +1,122 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="EFUtil.cs" company="Amazon.com">
+//      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+//      Licensed under the Apache License, Version 2.0 (the "License").
+//      You may not use this file except in compliance with the License.
+//      A copy of the License is located at
+//
+//      http://aws.amazon.com/apache2.0
+//
+//      or in the "license" file accompanying this file. This file is distributed
+//      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//      express or implied. See the License for the specific language governing
+//      permissions and limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Amazon.XRay.Recorder.Handlers.EntityFramework
+{
+    /// <summary>
+    /// Utilities for EFInterceptor
+    /// </summary>
+    public static class EFUtil
+    {
+        private static readonly string DefaultDatabaseType = "EntityFrameworkCore";
+
+        private static readonly string[] UserIdFormatOptions = { "user id", "username", "user" }; // case insensitive
+
+        // Some database providers may not support Entity Framework Core 3.0 and above now
+        // https://docs.microsoft.com/en-us/ef/core/providers/?tabs=dotnet-core-cli
+        private static readonly Dictionary<string, string> DatabaseTypes = new Dictionary<string, string>()
+        {
+            // Support tracing
+            { "Microsoft.EntityFrameworkCore.SqlServer" , "sqlserver" },
+            { "Microsoft.EntityFrameworkCore.Sqlite" , "sqlite" },
+            { "Npgsql.EntityFrameworkCore.PostgreSQL" , "postgresql" },
+            { "Pomelo.EntityFrameworkCore.MySql" , "mysql" },
+            { "FirebirdSql.EntityFrameworkCore.Firebird" , "firebirdsql" },
+
+            // Not support tracing so far
+            { "Microsoft.EntityFrameworkCore.InMemory" , "inmemory" },
+            { "Microsoft.EntityFrameworkCore.Cosmos" , "cosmosdb" },
+            { "Devart.Data.MySql.EFCore" , "mysql" },
+            { "Devart.Data.Oracle.EFCore" , "oracle" },
+            { "Devart.Data.PostgreSql.EFCore" , "postgresql" },
+            { "Devart.Data.SQLite.EFCore" , "sqlite" },
+            { "FileContextCore" , "filecontextcore" },
+            { "EntityFrameworkCore.Jet" , "jet" },
+            { "EntityFrameworkCore.SqlServerCompact35" , "sqlservercompact35" },
+            { "EntityFrameworkCore.SqlServerCompact40" , "sqlservercompact40" },
+            { "Teradata.EntityFrameworkCore" , "teradata" },
+            { "EntityFrameworkCore.FirebirdSql" , "firebirdsql" },
+            { "EntityFrameworkCore.OpenEdge" , "openedge" },
+            { "MySql.Data.EntityFrameworkCore" , "mysql" },
+            { "Oracle.EntityFrameworkCore" , "oracle" },
+            { "IBM.EntityFrameworkCore" , "ibm" },
+            { "IBM.EntityFrameworkCore-lnx" , "ibm" },
+            { "IBM.EntityFrameworkCore-osx" , "ibm" },
+            { "Pomelo.EntityFrameworkCore.MyCat" , "mycat" }
+        };
+
+        private static readonly Regex _portNumberRegex = new Regex(@"[,|:]\d+$");
+
+        /// <summary>
+        /// Extract database_type from <see cref="DbContext"/>.
+        /// </summary>
+        /// <param name="context">Instance of <see cref="DbContext"/>.</param>
+        /// <returns>Type of database.</returns>
+        public static string GetDataBaseType(DbContext context)
+        {
+            string databaseProvider = context?.Database?.ProviderName;
+
+            // Need to check if the context and its following parameter is null or not to avoid exception
+            if (string.IsNullOrEmpty(databaseProvider))
+            {
+                return DefaultDatabaseType;
+            }
+
+            string value = null;
+
+            if (DatabaseTypes.TryGetValue(databaseProvider, out value))
+            {
+                return value;
+            }
+
+            return databaseProvider;
+        }
+
+        /// <summary>
+        /// Extract user id from <see cref="DbConnectionStringBuilder"/>.
+        /// </summary>
+        /// <param name="builder">Instance of <see cref="DbConnectionStringBuilder"/>.</param>
+        /// <returns></returns>
+        public static object GetConnectionValue(DbConnectionStringBuilder builder)
+        {
+            object value = null;
+            foreach (string key in UserIdFormatOptions)
+            {
+                if (builder.TryGetValue(key, out value))
+                {
+                    break;
+                }
+            }
+            return value;
+        }
+
+        /// <summary>
+        /// Removes the port number from data source.
+        /// </summary>
+        /// <param name="dataSource">The data source.</param>
+        /// <returns>The data source string with port number removed.</returns>
+        public static string RemovePortNumberFromDataSource(string dataSource)
+        {
+            return _portNumberRegex.Replace(dataSource, string.Empty);
+        }
+    }
+}


### PR DESCRIPTION
*Issue:*

Added support for tracing SQL query through Entity Framework Core 3.0 and above. (.NET Core)

*Description of changes:*

Entity Framework 3.0 starts to include `DbCommandInterceptor` for interception of database operations.

https://docs.microsoft.com/en-us/ef/core/what-is-new/ef-core-3.0/#interception-of-database-operations

https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.diagnostics.dbcommandinterceptor?view=efcore-3.0

Integrated `DbCommandInterceptor` with AWS XRay SDK to enable tracing SQL query through EF Core 3.0 and above.  

* Extract `database_type` from `CommandEventData.Context`.
* Subsegment name is correctly collected via `DbCommand` through EF Core.
* `CollectSqlQueries` option can be enabled locally or globally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
