### PR TITLE
Imdsv2 support

### DIFF
--- a/sdk/src/Core/Plugins/EC2Plugin.cs
+++ b/sdk/src/Core/Plugins/EC2Plugin.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Amazon.Runtime.Internal.Util;
@@ -30,7 +31,7 @@ namespace Amazon.XRay.Recorder.Core.Plugins
     public class EC2Plugin : IPlugin
     {
         private static readonly Logger _logger = Logger.GetLogger(typeof(EC2Plugin));
-        private static readonly HttpClient _client = new HttpClient();
+        private readonly HttpClient _client = new HttpClient();
 
         /// <summary>
         /// Gets the name of the origin associated with this plugin.
@@ -77,7 +78,8 @@ namespace Amazon.XRay.Recorder.Core.Plugins
 
                 header = new Dictionary<string, string>(1);
                 header.Add("X-aws-ec2-metadata-token", token);
-
+                
+                // get the metadata
                 string resp = DoRequest(metadata_base_url + "dynamic/instance-identity/document", HttpMethod.Get, header).Result;
                 dict = ParseMetadata(resp);
             }
@@ -104,7 +106,7 @@ namespace Amazon.XRay.Recorder.Core.Plugins
             return true;
         }
 
-        private static async Task<string> DoRequest(string url, HttpMethod method, Dictionary<string, string> headers = null)
+        protected virtual async Task<string> DoRequest(string url, HttpMethod method, Dictionary<string, string> headers = null)
         {
             HttpRequestMessage request = new HttpRequestMessage(method, url);
             if (headers != null)
@@ -126,7 +128,8 @@ namespace Amazon.XRay.Recorder.Core.Plugins
             }
         }
 
-        private static Dictionary<string, object> ParseMetadata(string jsonString)
+
+        private Dictionary<string, object> ParseMetadata(string jsonString)
         {
             JsonData data = JsonMapper.ToObject(jsonString);
             Dictionary<string, object> ec2_meta_dict = new Dictionary<string, object>();

--- a/sdk/src/Core/Plugins/EC2Plugin.cs
+++ b/sdk/src/Core/Plugins/EC2Plugin.cs
@@ -65,21 +65,18 @@ namespace Amazon.XRay.Recorder.Core.Plugins
         /// <returns>true if the runtime context is available; Otherwise, false.</returns>
         public bool TryGetRuntimeContext(out IDictionary<string, object> context)
         {
-            context = null;
-
             // get the token
             string token = GetToken();
 
             // get the metadata
-            IDictionary<string, object> dict = GetMetadata(token);
+            context = GetMetadata(token);
 
-            if (dict.Count == 0)
+            if (context.Count == 0)
             {
                 _logger.DebugFormat("Could not get instance metadata");
                 return false;
             }
 
-            context = dict;
             return true;
         }
 

--- a/sdk/src/Core/Plugins/EC2Plugin.cs
+++ b/sdk/src/Core/Plugins/EC2Plugin.cs
@@ -61,20 +61,19 @@ namespace Amazon.XRay.Recorder.Core.Plugins
         /// <summary>
         /// Gets the context of the runtime that this plugin is associated with.
         /// </summary>
-        /// <param name="context">When the method returns, contains the runtime context of the plugin, or null if the runtime context is not available.</param>
+        /// <param name="context">When the method returns, contains the runtime context of the plugin.</param>
         /// <returns>true if the runtime context is available; Otherwise, false.</returns>
         public bool TryGetRuntimeContext(out IDictionary<string, object> context)
         {
             context = null;
-            IDictionary<string, object> dict = new Dictionary<string, object>();
 
             // get the token
             string token = GetToken();
 
             // get the metadata
-            dict = GetMetadata(token);
+            IDictionary<string, object> dict = GetMetadata(token);
 
-            if (dict == null || dict.Count == 0)
+            if (dict.Count == 0)
             {
                 _logger.DebugFormat("Could not get instance metadata");
                 return false;
@@ -119,7 +118,7 @@ namespace Amazon.XRay.Recorder.Core.Plugins
             catch (Exception)
             {
                 _logger.DebugFormat("Error occurred while getting EC2 metadata");
-                return null;
+                return new Dictionary<string, object>();
             }
         }
 

--- a/sdk/test/UnitTests/TestEC2Plugin.cs
+++ b/sdk/test/UnitTests/TestEC2Plugin.cs
@@ -1,0 +1,152 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="TestPlugins.cs" company="Amazon.com">
+//      Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+//      Licensed under the Apache License, Version 2.0 (the "License").
+//      You may not use this file except in compliance with the License.
+//      A copy of the License is located at
+//
+//      http://aws.amazon.com/apache2.0
+//
+//      or in the "license" file accompanying this file. This file is distributed
+//      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//      express or implied. See the License for the specific language governing
+//      permissions and limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Amazon.XRay.Recorder.Core.Plugins;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+
+namespace Amazon.XRay.Recorder.UnitTests
+{
+    [TestClass]
+    public class TestEC2Plugin
+    {
+
+        [TestMethod]
+        public void TestV2Success()
+        {
+            // Arrange
+            EC2Plugin ec2_plugin = new MockEC2Plugin(failV1: false, failV2: false);
+            IDictionary<string, object> context = new Dictionary<string, object>();
+
+            // Act
+            bool ret = ec2_plugin.TryGetRuntimeContext(out context);
+
+            // Assert
+            Assert.IsTrue(ret);
+            Assert.AreEqual(4, context.Count);
+            
+            object instance_id = "";
+            context.TryGetValue("instance_id", out instance_id);
+            Assert.AreEqual("i-07a181803de94c666", instance_id.ToString());
+
+            object availability_zone = "";
+            context.TryGetValue("availability_zone", out availability_zone);
+            Assert.AreEqual("us-east-2a", availability_zone.ToString());
+
+            object instance_size = "";
+            context.TryGetValue("instance_size", out instance_size);
+            Assert.AreEqual("t3.xlarge", instance_size.ToString());
+
+            object ami_id = "";
+            context.TryGetValue("ami_id", out ami_id);
+            Assert.AreEqual("ami-03cca83dd001d4666", ami_id.ToString());
+        }
+
+        [TestMethod]
+        public void TestV2Fail_V1Success()
+        {
+            // Arrange
+            EC2Plugin ec2_plugin = new MockEC2Plugin(failV1: false, failV2: true);
+            IDictionary<string, object> context = new Dictionary<string, object>();
+            
+            // Act
+            bool ret = ec2_plugin.TryGetRuntimeContext(out context);
+
+            // Assert
+            Assert.IsTrue(ret);
+            Assert.AreEqual(4, context.Count);
+            object instance_id = "";
+            context.TryGetValue("instance_id", out instance_id);
+            Assert.AreEqual("i-07a181803de94c477", instance_id.ToString());
+
+            object availability_zone = "";
+            context.TryGetValue("availability_zone", out availability_zone);
+            Assert.AreEqual("us-west-2a", availability_zone.ToString());
+
+            object instance_size = "";
+            context.TryGetValue("instance_size", out instance_size);
+            Assert.AreEqual("t2.xlarge", instance_size.ToString());
+
+            object ami_id = "";
+            context.TryGetValue("ami_id", out ami_id);
+            Assert.AreEqual("ami-03cca83dd001d4d11", ami_id.ToString());
+        }
+
+        [TestMethod]
+        public void TestV2Fail_V1Fail()
+        {
+            // Arrange
+            EC2Plugin ec2_plugin = new MockEC2Plugin(failV1: true, failV2: true);
+            IDictionary<string, object> context = new Dictionary<string, object>();
+
+            // Act
+            bool ret = ec2_plugin.TryGetRuntimeContext(out context);
+
+            // Assert
+            Assert.IsFalse(ret);
+            Assert.IsNull(context);
+        }
+    }
+
+    // This is a mock class created for the purpose of unit testing. The overridden DoRequest method returns valid values or Exception 
+    // based on the conditions for the tests. 
+    public class MockEC2Plugin : EC2Plugin
+    {
+        private readonly bool _failV2;
+        private readonly bool _failV1;
+
+        public MockEC2Plugin(bool failV1, bool failV2)
+        {
+            _failV1 = failV1;
+            _failV2 = failV2;
+        }
+
+        protected override Task<string> DoRequest(string url, HttpMethod method, Dictionary<string, string> headers = null)
+        {
+            if (_failV2 && url == "http://169.254.169.254/latest/api/token")
+            {
+                throw new Exception("Unable to complete the v2 request successfully");
+            }
+            else if (!_failV2 && url == "http://169.254.169.254/latest/api/token")
+            {
+                return Task.FromResult("dummyTokenfromferg");
+            }
+            else if (_failV1)
+            {
+                throw new Exception("Unable to complete the v1 request successfully");
+            }
+            
+            string meta_string = "";
+            if (headers == null) // for v1 endpoint request
+            {
+                meta_string = "{\"availabilityZone\" : \"us-west-2a\", \"imageId\" : \"ami-03cca83dd001d4d11\", \"instanceId\" : \"i-07a181803de94c477\", \"instanceType\" : \"t2.xlarge\"}";
+                return Task.FromResult(meta_string);
+            }
+            else
+            { // for v2 endpoint
+                meta_string = "{\"availabilityZone\" : \"us-east-2a\", \"imageId\" : \"ami-03cca83dd001d4666\", \"instanceId\" : \"i-07a181803de94c666\", \"instanceType\" : \"t3.xlarge\"}";
+                return Task.FromResult(meta_string);
+            }
+        }
+
+    }
+    
+}

--- a/sdk/test/UnitTests/TestEC2Plugin.cs
+++ b/sdk/test/UnitTests/TestEC2Plugin.cs
@@ -102,7 +102,7 @@ namespace Amazon.XRay.Recorder.UnitTests
 
             // Assert
             Assert.IsFalse(ret);
-            Assert.IsNull(context);
+            Assert.AreEqual(0, context.Count);
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding IMDSv2 support for fetching the EC2 instance metadata via the EC2Plugin. The metadata is fetched from [instance identity document](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html) with a fallback to V1 if V2 fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
