### PR TITLE
Added timeout for EC2 metadata requests

### DIFF
--- a/sdk/src/Core/Plugins/EC2Plugin.cs
+++ b/sdk/src/Core/Plugins/EC2Plugin.cs
@@ -131,6 +131,7 @@ namespace Amazon.XRay.Recorder.Core.Plugins
                 }
             }
 
+            _client.Timeout = TimeSpan.FromSeconds(2); // 2 seconds timeout
             HttpResponseMessage response = await _client.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {


### PR DESCRIPTION
*Issue #, if available:*  [135](https://github.com/aws/aws-xray-sdk-dotnet/issues/135)

*Description of changes:*
Adding a 2 seconds timeout to EC2 plugin while fetching metadata from IMDS endpoint.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
