### PR TITLE
Update NOTICE so it only has third party licenses and no proprietary …

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,6 +1,3 @@
-AWS X-Ray Recorder SDK for .NET
-Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
 **********************
 THIRD PARTY COMPONENTS
 **********************


### PR DESCRIPTION
…notice

Not sure why we have a proprietary license in the notice of .NET repos but it's wrong. IANAL but the fact that we call out Apache License in `README.txt` probably means Apache takes precedence, but I may encourage a hotfix release just to make sure there is a released binary without this license complication.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
