### PR TITLE
Updated xraycontext to use a concurrent dictionary

### DIFF
--- a/sdk/src/Core/AWSXRayRecorderImpl.cs
+++ b/sdk/src/Core/AWSXRayRecorderImpl.cs
@@ -15,6 +15,7 @@
 // </copyright>
 //-----------------------------------------------------------------------------
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
@@ -379,13 +380,12 @@ namespace Amazon.XRay.Recorder.Core
             IDictionary<string, string> xrayContext;
             if (newSegment.Aws.TryGetValue("xray", out object value))
             {
-                IDictionary<string, string> tempXrayContext = (Dictionary<string, string>) value;
-                xrayContext = new Dictionary<string, string>(tempXrayContext); // deep copy for thread safety
+                xrayContext = (ConcurrentDictionary<string, string>)value;
                 xrayContext[ruleNameKey] = ruleName;
             }
             else
             {
-                xrayContext = new Dictionary<string, string>();
+                xrayContext = new ConcurrentDictionary<string, string>();
                 xrayContext[ruleNameKey] = ruleName;
             }
 
@@ -725,7 +725,7 @@ namespace Amazon.XRay.Recorder.Core
             RuntimeContext = new Dictionary<string, object>();
 
             // Prepare XRay section for runtime context
-            var xrayContext = new Dictionary<string, string>();
+            var xrayContext = new ConcurrentDictionary<string, string>();
 
 #if NET45
             xrayContext["sdk"] = "X-Ray for .NET";

--- a/sdk/test/UnitTests/AWSXRayRecorderTests.cs
+++ b/sdk/test/UnitTests/AWSXRayRecorderTests.cs
@@ -16,6 +16,7 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Diagnostics;
@@ -768,7 +769,7 @@ namespace Amazon.XRay.Recorder.UnitTests
             var segment = AWSXRayRecorder.Instance.TraceContext.GetEntity();
             _recorder.EndSegment();
 
-            IDictionary<string, string> xray = (Dictionary<string, string>)segment.Aws["xray"];
+            IDictionary<string, string> xray = (ConcurrentDictionary<string, string>)segment.Aws["xray"];
             var versionText =
                 FileVersionInfo.GetVersionInfo(Assembly.GetAssembly(typeof(AWSXRayRecorderBuilder)).Location)
                     .ProductVersion;


### PR DESCRIPTION
To avoid concurrent thread access to the dictionary causing an exception

fixes #156 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
