### PR TITLE
Add support for EF Core 5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: '1.0.{build}'
-image: Visual Studio 2017
+image: Visual Studio 2019
 init:
   # Good practise, because Windows line endings are different from Unix/Linux ones
   - cmd: git config --global core.autocrlf true

--- a/sdk/src/Handlers/EntityFramework/AWSXRayRecorder.Handlers.EntityFramework.csproj
+++ b/sdk/src/Handlers/EntityFramework/AWSXRayRecorder.Handlers.EntityFramework.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -30,8 +30,12 @@
     <NoWarn>1701;1702;1591;</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/src/Handlers/EntityFramework/EFInterceptor.cs
+++ b/sdk/src/Handlers/EntityFramework/EFInterceptor.cs
@@ -80,7 +80,11 @@ namespace Amazon.XRay.Recorder.Handlers.EntityFramework
         /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
         /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
         /// <returns>Task representing the async operation.</returns>
+#if NET5_0
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result, CancellationToken cancellationToken = default)
+#else
         public override Task<InterceptionResult<DbDataReader>> ReaderExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result, CancellationToken cancellationToken = default)
+#endif
         {
             ProcessBeginCommand(eventData);
             return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
@@ -94,7 +98,11 @@ namespace Amazon.XRay.Recorder.Handlers.EntityFramework
         /// <param name="result">Result from <see cref="DbDataReader"/>.</param>
         /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
         /// <returns>Task representing the async operation.</returns>
+#if NET5_0
+        public override ValueTask<DbDataReader> ReaderExecutedAsync(DbCommand command, CommandExecutedEventData eventData, DbDataReader result, CancellationToken cancellationToken = default)
+#else
         public override Task<DbDataReader> ReaderExecutedAsync(DbCommand command, CommandExecutedEventData eventData, DbDataReader result, CancellationToken cancellationToken = default)
+#endif
         {
             ProcessEndCommand();
             return base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
@@ -145,7 +153,11 @@ namespace Amazon.XRay.Recorder.Handlers.EntityFramework
         /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
         /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
         /// <returns>Task representing the async operation.</returns>
+#if NET5_0
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+#else
         public override Task<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+#endif
         {
             ProcessBeginCommand(eventData);
             return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
@@ -172,7 +184,11 @@ namespace Amazon.XRay.Recorder.Handlers.EntityFramework
         /// <param name="result">Result as integer.</param>
         /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
         /// <returns>Task representing the async operation.</returns>
+#if NET5_0
+        public override ValueTask<int> NonQueryExecutedAsync(DbCommand command, CommandExecutedEventData eventData, int result, CancellationToken cancellationToken = default)
+#else
         public override Task<int> NonQueryExecutedAsync(DbCommand command, CommandExecutedEventData eventData, int result, CancellationToken cancellationToken = default)
+#endif
         {
             ProcessEndCommand();
             return base.NonQueryExecutedAsync(command, eventData, result, cancellationToken);
@@ -199,7 +215,11 @@ namespace Amazon.XRay.Recorder.Handlers.EntityFramework
         /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
         /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
         /// <returns>Task representing the async operation.</returns>
+#if NET5_0
+        public override ValueTask<InterceptionResult<object>> ScalarExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<object> result, CancellationToken cancellationToken = default)
+#else
         public override Task<InterceptionResult<object>> ScalarExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<object> result, CancellationToken cancellationToken = default)
+#endif
         {
             ProcessBeginCommand(eventData);
             return base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
@@ -226,7 +246,11 @@ namespace Amazon.XRay.Recorder.Handlers.EntityFramework
         /// <param name="result">Result object.</param>
         /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
         /// <returns>Task representing the async operation.</returns>
+#if NET5_0
+        public override ValueTask<object> ScalarExecutedAsync(DbCommand command, CommandExecutedEventData eventData, object result, CancellationToken cancellationToken = default)
+#else
         public override Task<object> ScalarExecutedAsync(DbCommand command, CommandExecutedEventData eventData, object result, CancellationToken cancellationToken = default)
+#endif
         {
             ProcessEndCommand();
             return base.ScalarExecutedAsync(command, eventData, result, cancellationToken);

--- a/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
+++ b/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.1;net5.0</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -10,56 +10,55 @@
     <FileVersion>1.1.0.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../../buildtools/local-development.snk</AssemblyOriginatorKeyFile>
+    <NoWarn>0618;1701;1702;1705</NoWarn>
   </PropertyGroup>
 
   
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net452|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
-    <NoWarn>0618;1701;1702;1705</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net452|AnyCPU'">
-    <NoWarn>0618;1701;1702;1705</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)'=='net452'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">
     <DefineConstants>NET45</DefineConstants>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-    <NoWarn>0618;1701;1702;1705</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.0|AnyCPU'">
-    <NoWarn>0618;1701;1702;1705</NoWarn>
-  </PropertyGroup>
-
+  
   <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.5.1.23" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.1.1" />
     <PackageReference Include="AWSSDK.Lambda" Version="3.5.0.25" />
     <PackageReference Include="AWSSDK.S3" Version="3.5.3.1" />
     <PackageReference Include="Moq" Version="4.7.137" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0">
-    </PackageReference>
 
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0">
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+    <Reference Include="System.Web" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <ProjectReference Include="..\..\src\Handlers\EntityFramework\AWSXRayRecorder.Handlers.EntityFramework.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.0.0" />
-    <ProjectReference Include="..\..\src\Handlers\EntityFramework\AWSXRayRecorder.Handlers.EntityFramework.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.0" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\AWSXRayRecorder.Core.csproj" />
     <ProjectReference Include="..\..\src\Handlers\AwsSdk\AWSXRayRecorder.Handlers.AwsSdk.csproj" />
@@ -68,13 +67,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-
     <Compile Remove="TestAppSettings.cs" />
     <Compile Remove="Tools\MockHttpRequest.cs" />
     <Compile Remove="Tools\MockHttpRequestFactory.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <Compile Remove="Tools\MockHttpRequestNetcore.cs" />
     <Compile Remove="Tools\MockHttpRequestFactoryNetcore.cs" />
     <Compile Remove="Tools\CustomWebResponse.cs" />
@@ -84,10 +82,6 @@
     <Compile Remove="FacadeSegmentTest.cs" />
     <Compile Remove="EfCoreTests.cs" />
     <Compile Remove="EFUtilTests.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Web" />
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/test/UnitTests/EfCoreTests.cs
+++ b/sdk/test/UnitTests/EfCoreTests.cs
@@ -95,7 +95,7 @@ namespace Amazon.XRay.Recorder.UnitTests
 
             try
             {
-                context.Database.ExecuteSqlCommand("Select * From FakeTable"); // A false sql command which results in 'no such table: FakeTable' exception
+                context.Database.ExecuteSqlRaw("Select * From FakeTable"); // A false sql command which results in 'no such table: FakeTable' exception
             }
             catch
             {

--- a/sdk/test/UnitTests/JsonSegmentMarshallerTest.cs
+++ b/sdk/test/UnitTests/JsonSegmentMarshallerTest.cs
@@ -190,7 +190,11 @@ namespace Amazon.XRay.Recorder.UnitTests
                 var filePath = trace.GetFrame(0).GetFileName().Replace("\\", "\\\\");
                 var line = new StackTrace(e, true).GetFrame(0).GetFileLineNumber();
                 var workingDirectory = Directory.GetCurrentDirectory().Replace("\\", "\\\\");
+#if NET5_0
+                var expected = "{\"format\":\"json\",\"version\":1}\n{\"id\":\"1111111111111111\",\"start_time\":0,\"end_time\":0,\"name\":\"test\",\"fault\":true,\"cause\":{\"working_directory\":\"" + workingDirectory + "\",\"exceptions\":[{\"id\":\"" + subsegment.Cause.ExceptionDescriptors[0].Id + "\",\"message\":\"Value cannot be null. (Parameter 'value')\",\"type\":\"ArgumentNullException\",\"remote\":false,\"stack\":[{\"path\":\"" + filePath + "\",\"line\":" + line + ",\"label\":\"Amazon.XRay.Recorder.UnitTests.JsonSegmentMarshallerTest.TestMarshallAddException\"}]}]}}";
+#else
                 var expected = "{\"format\":\"json\",\"version\":1}\n{\"id\":\"1111111111111111\",\"start_time\":0,\"end_time\":0,\"name\":\"test\",\"fault\":true,\"cause\":{\"working_directory\":\"" + workingDirectory + "\",\"exceptions\":[{\"id\":\"" + subsegment.Cause.ExceptionDescriptors[0].Id + "\",\"message\":\"Value cannot be null." + Environment.NewLine.Replace("\r", @"\r").Replace("\n", @"\n") + "Parameter name: value\",\"type\":\"ArgumentNullException\",\"remote\":false,\"stack\":[{\"path\":\"" + filePath + "\",\"line\":" + line + ",\"label\":\"Amazon.XRay.Recorder.UnitTests.JsonSegmentMarshallerTest.TestMarshallAddException\"}]}]}}";
+#endif
 
                 Assert.AreEqual(expected, actual);
             }


### PR DESCRIPTION
[IDbCommandInterceptor](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.diagnostics.idbcommandinterceptor?view=efcore-5.0) interface has changed in EF Core 5.0. All but one asynchronous methods now return [ValueTask](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.valuetask-1?view=net-5.0). 

No exceptions are thrown when using the netstandard2.0 in a net50 / ef core 5 project. But EFInterceptor does not work.

This PR adds net5.0 as a target framework to the EntityFramework project and uses preprocessor directives to conditionally change the method signatures to support EF Core 5.

I can update PR to target netstandard2.1 in addition to OR instead of net50.