### PR TITLE
Fixed appvoyer building configuration issue.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ before_build:
 build_script:
   # output will be in ./src/bin/debug/netcoreapp1.1/publish
   - cmd: dotnet restore sdk/AWSXRayRecorder.sln
-  - cmd: dotnet build sdk/AWSXRayRecorder.sln /p:SignAssembly=false
+  - cmd: dotnet build sdk/AWSXRayRecorder.sln
 clone_depth: 1
 test_script:
   - cmd : dotnet test sdk/test/UnitTests


### PR DESCRIPTION
*Issue #, if available:*

#172 

*Description of changes:*

Remove `/p:SignAssembly=false` and let projects be built by their default settings for signing assemblies or not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
