### PR TITLE
Upgrade the existing EntityFramework NuGet package with EF5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,11 +388,13 @@ using (var command = new TraceableSqlCommand("SELECT * FROM products", connectio
 
 AWS XRay SDK for .NET Core provides interceptor for tracing SQL query through Entity Framework Core (>=3.0).
 
-For how to start with Entity Framework Core in an ASP.NET Core web app, please take reference to [Link](https://docs.microsoft.com/en-us/aspnet/core/data/ef-mvc/?view=aspnetcore-3.1)
+For how to start with Entity Framework Core in an ASP.NET Core web app, please take reference to [Link](https://docs.microsoft.com/en-us/aspnet/core/data/ef-mvc/?view=aspnetcore-5.0)
 
 *NOTE:*
 
 * You need to install `AWSXRayRecorder.Handlers.EntityFramework` nuget package. This package adds extension methods to the `DbContextOptionsBuilder` to make it easy to register AWS X-Ray interceptor.
+* If you are using Entity Framework Core 5.0 and above, use version `5.0` (or above) of the `AWSXRayRecorder.Handlers.EntityFramework` nuget package.
+* If you are using Entity Framework Core 3.0 or 3.1, use version `1.0.1` of the `AWSXRayRecorder.Handlers.EntityFramework` nuget package.
 * Not all database provider support Entity Framework Core 3.0 and above, please make sure that you are using the [Nuget package](https://docs.microsoft.com/en-us/ef/core/providers/?tabs=dotnet-core-cli) with a compatible version (EF Core >= 3.0).
 
 *Known Limitation (as of 12-03-2020):* If you're using another `DbCommandInterceptor` implementation along with the `AddXRayInterceptor` in the `DbContext`, it may not work as expected and you may see a "EntityNotAvailableException" from the XRay EFCore interceptor. This is due to [`AsyncLocal`](https://docs.microsoft.com/en-us/dotnet/api/system.threading.asynclocal-1?view=netcore-2.0) not being able to maintain context across the `ReaderExecutingAsync` and `ReaderExecutedAsync` methods. Ref [here](https://github.com/dotnet/efcore/issues/22766) for more details on the issue.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: '1.0.{build}'
-image: Visual Studio 2017
+image: Visual Studio 2019
 init:
   # Good practise, because Windows line endings are different from Unix/Linux ones
   - cmd: git config --global core.autocrlf true

--- a/sdk/src/Handlers/EntityFramework/AWSXRayRecorder.Handlers.EntityFramework.csproj
+++ b/sdk/src/Handlers/EntityFramework/AWSXRayRecorder.Handlers.EntityFramework.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1.0</FileVersion>
-    <Version>1.0.1</Version>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <FileVersion>5.0.0.0</FileVersion>
+    <Version>5.0.0</Version>
     <AssemblyName>AWSXRayRecorder.Handlers.EntityFramework</AssemblyName>
     <RootNamespace>Amazon.XRay.Recorder.Handlers.EntityFramework</RootNamespace>
     <Authors>Amazon Web Services</Authors>
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/src/Handlers/EntityFramework/EFInterceptor.cs
+++ b/sdk/src/Handlers/EntityFramework/EFInterceptor.cs
@@ -80,7 +80,7 @@ namespace Amazon.XRay.Recorder.Handlers.EntityFramework
         /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
         /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
         /// <returns>Task representing the async operation.</returns>
-        public override Task<InterceptionResult<DbDataReader>> ReaderExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result, CancellationToken cancellationToken = default)
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result, CancellationToken cancellationToken = default)
         {
             ProcessBeginCommand(eventData);
             return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
@@ -94,7 +94,7 @@ namespace Amazon.XRay.Recorder.Handlers.EntityFramework
         /// <param name="result">Result from <see cref="DbDataReader"/>.</param>
         /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
         /// <returns>Task representing the async operation.</returns>
-        public override Task<DbDataReader> ReaderExecutedAsync(DbCommand command, CommandExecutedEventData eventData, DbDataReader result, CancellationToken cancellationToken = default)
+        public override ValueTask<DbDataReader> ReaderExecutedAsync(DbCommand command, CommandExecutedEventData eventData, DbDataReader result, CancellationToken cancellationToken = default)
         {
             ProcessEndCommand();
             return base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
@@ -125,7 +125,7 @@ namespace Amazon.XRay.Recorder.Handlers.EntityFramework
         }
 
         /// <summary>
-        /// Trace before excuting.
+        /// Trace before executing.
         /// </summary>
         /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
         /// <param name="eventData">Instance of <see cref="CommandEventData"/>.</param>
@@ -145,7 +145,7 @@ namespace Amazon.XRay.Recorder.Handlers.EntityFramework
         /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
         /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
         /// <returns>Task representing the async operation.</returns>
-        public override Task<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
         {
             ProcessBeginCommand(eventData);
             return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
@@ -172,7 +172,7 @@ namespace Amazon.XRay.Recorder.Handlers.EntityFramework
         /// <param name="result">Result as integer.</param>
         /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
         /// <returns>Task representing the async operation.</returns>
-        public override Task<int> NonQueryExecutedAsync(DbCommand command, CommandExecutedEventData eventData, int result, CancellationToken cancellationToken = default)
+        public override ValueTask<int> NonQueryExecutedAsync(DbCommand command, CommandExecutedEventData eventData, int result, CancellationToken cancellationToken = default)
         {
             ProcessEndCommand();
             return base.NonQueryExecutedAsync(command, eventData, result, cancellationToken);
@@ -199,7 +199,7 @@ namespace Amazon.XRay.Recorder.Handlers.EntityFramework
         /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
         /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
         /// <returns>Task representing the async operation.</returns>
-        public override Task<InterceptionResult<object>> ScalarExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<object> result, CancellationToken cancellationToken = default)
+        public override ValueTask<InterceptionResult<object>> ScalarExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<object> result, CancellationToken cancellationToken = default)
         {
             ProcessBeginCommand(eventData);
             return base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
@@ -226,7 +226,7 @@ namespace Amazon.XRay.Recorder.Handlers.EntityFramework
         /// <param name="result">Result object.</param>
         /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
         /// <returns>Task representing the async operation.</returns>
-        public override Task<object> ScalarExecutedAsync(DbCommand command, CommandExecutedEventData eventData, object result, CancellationToken cancellationToken = default)
+        public override ValueTask<object> ScalarExecutedAsync(DbCommand command, CommandExecutedEventData eventData, object result, CancellationToken cancellationToken = default)
         {
             ProcessEndCommand();
             return base.ScalarExecutedAsync(command, eventData, result, cancellationToken);

--- a/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
+++ b/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -26,12 +26,12 @@
     <DefineConstants>NET45</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <NoWarn>0618;1701;1702;1705</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|AnyCPU'">
     <NoWarn>0618;1701;1702;1705</NoWarn>
   </PropertyGroup>
 
@@ -43,16 +43,16 @@
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.0.26" />
     <PackageReference Include="Moq" Version="4.7.137" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0">
     </PackageReference>
 
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0">
     </PackageReference>
 
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.0.0" />
     <ProjectReference Include="..\..\src\Handlers\EntityFramework\AWSXRayRecorder.Handlers.EntityFramework.csproj" />
   </ItemGroup>
@@ -75,7 +75,7 @@
     <Compile Remove="Tools\MockHttpRequest.cs" />
     <Compile Remove="Tools\MockHttpRequestFactory.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <Compile Remove="Tools\MockHttpRequestNetcore.cs" />
     <Compile Remove="Tools\MockHttpRequestFactoryNetcore.cs" />
     <Compile Remove="Tools\CustomWebResponse.cs" />

--- a/sdk/test/UnitTests/EfCoreTests.cs
+++ b/sdk/test/UnitTests/EfCoreTests.cs
@@ -95,7 +95,7 @@ namespace Amazon.XRay.Recorder.UnitTests
 
             try
             {
-                context.Database.ExecuteSqlCommand("Select * From FakeTable"); // A false sql command which results in 'no such table: FakeTable' exception
+                context.Database.ExecuteSqlRaw("Select * From FakeTable"); // A false sql command which results in 'no such table: FakeTable' exception
             }
             catch
             {

--- a/sdk/test/UnitTests/JsonSegmentMarshallerTest.cs
+++ b/sdk/test/UnitTests/JsonSegmentMarshallerTest.cs
@@ -190,7 +190,11 @@ namespace Amazon.XRay.Recorder.UnitTests
                 var filePath = trace.GetFrame(0).GetFileName().Replace("\\", "\\\\");
                 var line = new StackTrace(e, true).GetFrame(0).GetFileLineNumber();
                 var workingDirectory = Directory.GetCurrentDirectory().Replace("\\", "\\\\");
+#if NETCOREAPP3_1
+                var expected = "{\"format\":\"json\",\"version\":1}\n{\"id\":\"1111111111111111\",\"start_time\":0,\"end_time\":0,\"name\":\"test\",\"fault\":true,\"cause\":{\"working_directory\":\"" + workingDirectory + "\",\"exceptions\":[{\"id\":\"" + subsegment.Cause.ExceptionDescriptors[0].Id + "\",\"message\":\"Value cannot be null. (Parameter 'value')\",\"type\":\"ArgumentNullException\",\"remote\":false,\"stack\":[{\"path\":\"" + filePath + "\",\"line\":" + line + ",\"label\":\"Amazon.XRay.Recorder.UnitTests.JsonSegmentMarshallerTest.TestMarshallAddException\"}]}]}}";
+#else
                 var expected = "{\"format\":\"json\",\"version\":1}\n{\"id\":\"1111111111111111\",\"start_time\":0,\"end_time\":0,\"name\":\"test\",\"fault\":true,\"cause\":{\"working_directory\":\"" + workingDirectory + "\",\"exceptions\":[{\"id\":\"" + subsegment.Cause.ExceptionDescriptors[0].Id + "\",\"message\":\"Value cannot be null." + Environment.NewLine.Replace("\r", @"\r").Replace("\n", @"\n") + "Parameter name: value\",\"type\":\"ArgumentNullException\",\"remote\":false,\"stack\":[{\"path\":\"" + filePath + "\",\"line\":" + line + ",\"label\":\"Amazon.XRay.Recorder.UnitTests.JsonSegmentMarshallerTest.TestMarshallAddException\"}]}]}}";
+#endif
 
                 Assert.AreEqual(expected, actual);
             }


### PR DESCRIPTION
This is one possible solution to https://github.com/aws/aws-xray-sdk-dotnet/issues/174

In this solution, we simply upgrade the existing package to EntityFramework 5, and bump the major version, as this is a breaking change. The new version of the package was also upgraded to NET Standard 2.1, as this is the minimum version of the standard supported by EF5.

In this solution, we would have to maintain a separate branch to provide updates to the EF3.1 version, which is not ideal.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
