### PR TITLE
Add new NuGet package of the EntityFramework Handler with support for EF5

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,11 +388,13 @@ using (var command = new TraceableSqlCommand("SELECT * FROM products", connectio
 
 AWS XRay SDK for .NET Core provides interceptor for tracing SQL query through Entity Framework Core (>=3.0).
 
-For how to start with Entity Framework Core in an ASP.NET Core web app, please take reference to [Link](https://docs.microsoft.com/en-us/aspnet/core/data/ef-mvc/?view=aspnetcore-3.1)
+For how to start with Entity Framework Core in an ASP.NET Core web app, please take reference to [Link](https://docs.microsoft.com/en-us/aspnet/core/data/ef-mvc/?view=aspnetcore-5.0)
 
 *NOTE:*
 
 * You need to install `AWSXRayRecorder.Handlers.EntityFramework` nuget package. This package adds extension methods to the `DbContextOptionsBuilder` to make it easy to register AWS X-Ray interceptor.
+* If you are using Entity Framework Core 5.0 and above, use the `AWSXRayRecorder.Handlers.EntityFramework5` nuget package.
+* If you are using Entity Framework Core 3.1, use the `AWSXRayRecorder.Handlers.EntityFramework` nuget package.
 * Not all database provider support Entity Framework Core 3.0 and above, please make sure that you are using the [Nuget package](https://docs.microsoft.com/en-us/ef/core/providers/?tabs=dotnet-core-cli) with a compatible version (EF Core >= 3.0).
 
 *Known Limitation (as of 12-03-2020):* If you're using another `DbCommandInterceptor` implementation along with the `AddXRayInterceptor` in the `DbContext`, it may not work as expected and you may see a "EntityNotAvailableException" from the XRay EFCore interceptor. This is due to [`AsyncLocal`](https://docs.microsoft.com/en-us/dotnet/api/system.threading.asynclocal-1?view=netcore-2.0) not being able to maintain context across the `ReaderExecutingAsync` and `ReaderExecutedAsync` methods. Ref [here](https://github.com/dotnet/efcore/issues/22766) for more details on the issue.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: '1.0.{build}'
-image: Visual Studio 2017
+image: Visual Studio 2019
 init:
   # Good practise, because Windows line endings are different from Unix/Linux ones
   - cmd: git config --global core.autocrlf true

--- a/sdk/AWSXRayRecorder.sln
+++ b/sdk/AWSXRayRecorder.sln
@@ -25,7 +25,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSXRayRecorder.UnitTests",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSXRayRecorder.Handlers.AspNet", "src\Handlers\AspNet\AWSXRayRecorder.Handlers.AspNet.csproj", "{C647F311-4023-4E0B-9147-074EAF243D54}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWSXRayRecorder.Handlers.EntityFramework", "src\Handlers\EntityFramework\AWSXRayRecorder.Handlers.EntityFramework.csproj", "{B5C2F674-6539-4A04-9B7D-14E300962BFE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSXRayRecorder.Handlers.EntityFramework", "src\Handlers\EntityFramework\AWSXRayRecorder.Handlers.EntityFramework.csproj", "{B5C2F674-6539-4A04-9B7D-14E300962BFE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWSXRayRecorder.Handlers.EntityFramework5", "src\Handlers\EntityFramework5\AWSXRayRecorder.Handlers.EntityFramework5.csproj", "{55D28FE2-BCC9-42E0-8A6B-1A5DE7666ED6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -88,6 +90,12 @@ Global
 		{B5C2F674-6539-4A04-9B7D-14E300962BFE}.Nuget|Any CPU.Build.0 = Release|Any CPU
 		{B5C2F674-6539-4A04-9B7D-14E300962BFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B5C2F674-6539-4A04-9B7D-14E300962BFE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{55D28FE2-BCC9-42E0-8A6B-1A5DE7666ED6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{55D28FE2-BCC9-42E0-8A6B-1A5DE7666ED6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{55D28FE2-BCC9-42E0-8A6B-1A5DE7666ED6}.Nuget|Any CPU.ActiveCfg = Debug|Any CPU
+		{55D28FE2-BCC9-42E0-8A6B-1A5DE7666ED6}.Nuget|Any CPU.Build.0 = Debug|Any CPU
+		{55D28FE2-BCC9-42E0-8A6B-1A5DE7666ED6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{55D28FE2-BCC9-42E0-8A6B-1A5DE7666ED6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -102,6 +110,7 @@ Global
 		{B7D60B1F-C452-454E-AD4B-202A40E628E8} = {F0ED74B6-1639-47D3-9511-B4217012AC88}
 		{C647F311-4023-4E0B-9147-074EAF243D54} = {6FD9C919-1504-445D-B70D-D0F8AC2829C4}
 		{B5C2F674-6539-4A04-9B7D-14E300962BFE} = {6FD9C919-1504-445D-B70D-D0F8AC2829C4}
+		{55D28FE2-BCC9-42E0-8A6B-1A5DE7666ED6} = {6FD9C919-1504-445D-B70D-D0F8AC2829C4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E3276CD5-62B3-466D-BFDD-2AFDB8819B46}

--- a/sdk/src/Handlers/EntityFramework5/AWSXRayInterceptorExtensions.cs
+++ b/sdk/src/Handlers/EntityFramework5/AWSXRayInterceptorExtensions.cs
@@ -1,0 +1,40 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="AWSXRayInterceptorExtensions.cs" company="Amazon.com">
+//      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+//      Licensed under the Apache License, Version 2.0 (the "License").
+//      You may not use this file except in compliance with the License.
+//      A copy of the License is located at
+//
+//      http://aws.amazon.com/apache2.0
+//
+//      or in the "license" file accompanying this file. This file is distributed
+//      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//      express or implied. See the License for the specific language governing
+//      permissions and limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+using Amazon.XRay.Recorder.Handlers.EntityFramework;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// Extension method for <see cref="DbContextOptionsBuilder"/> to add <see cref="EFInterceptor"/>.
+    /// User can pass collectSqlQueries to AddXRayInterceptor() to decide if sanitized_query should be included in the trace
+    /// context or not.
+    /// </summary>
+    public static class AWSXRayInterceptorExtensions
+    {
+        /// <summary>
+        /// Add <see cref="EFInterceptor"/> to <see cref="DbContextOptionsBuilder"/>.
+        /// </summary>
+        /// <param name="dbContextOptionsBuilder">Instance of <see cref="DbContextOptionsBuilder"/>.</param>
+        /// <param name="collectSqlQueries"></param>
+        /// <returns>Instance of <see cref="DbContextOptionsBuilder"/>.</returns>
+        public static DbContextOptionsBuilder AddXRayInterceptor(this DbContextOptionsBuilder dbContextOptionsBuilder, bool? collectSqlQueries = null)
+        {
+            return dbContextOptionsBuilder.AddInterceptors(new EFInterceptor(collectSqlQueries));
+        }
+    }
+}

--- a/sdk/src/Handlers/EntityFramework5/AWSXRayRecorder.Handlers.EntityFramework5.csproj
+++ b/sdk/src/Handlers/EntityFramework5/AWSXRayRecorder.Handlers.EntityFramework5.csproj
@@ -1,0 +1,41 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Company>Amazon.com, Inc</Company>
+    <Product>Amazon Web Service X-Ray Recorder</Product>
+    <Copyright>Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <FileVersion>5.0.0.0</FileVersion>
+    <Version>5.0.0</Version>
+    <AssemblyName>AWSXRayRecorder.Handlers.EntityFramework5</AssemblyName>
+    <RootNamespace>Amazon.XRay.Recorder.Handlers.EntityFramework</RootNamespace>
+    <Authors>Amazon Web Services</Authors>
+    <Description>This package contains libraries to trace SQL queries through Entity Framework Core.</Description>
+    <PackageLicenseUrl>http://aws.amazon.com/apache2.0/</PackageLicenseUrl>
+    <PackageProjectUrl>https://aws.amazon.com/documentation/xray/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/aws/aws-xray-sdk-dotnet</RepositoryUrl>
+    <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>
+    <PackageTags>AWS Amazon cloud AWSXRay XRay</PackageTags>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../../../../buildtools/local-development.snk</AssemblyOriginatorKeyFile>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591;</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;1591;</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\AWSXRayRecorder.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/src/Handlers/EntityFramework5/EFInterceptor.cs
+++ b/sdk/src/Handlers/EntityFramework5/EFInterceptor.cs
@@ -1,0 +1,331 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="EFInterceptor.cs" company="Amazon.com">
+//      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+//      Licensed under the Apache License, Version 2.0 (the "License").
+//      You may not use this file except in compliance with the License.
+//      A copy of the License is located at
+//
+//      http://aws.amazon.com/apache2.0
+//
+//      or in the "license" file accompanying this file. This file is distributed
+//      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//      express or implied. See the License for the specific language governing
+//      permissions and limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Amazon.XRay.Recorder.Core;
+using Amazon.XRay.Recorder.Core.Internal.Entities;
+using Amazon.XRay.Recorder.Core.Exceptions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Amazon.XRay.Recorder.Handlers.EntityFramework
+{
+    public class EFInterceptor : DbCommandInterceptor
+    {
+        private readonly AWSXRayRecorder _recorder;
+        private readonly bool? _collectSqlQueriesOverride;
+
+        public EFInterceptor() : this(AWSXRayRecorder.Instance)
+        {
+
+        }
+
+        public EFInterceptor(bool? collectSqlQueries = null) : this(AWSXRayRecorder.Instance, collectSqlQueries)
+        {
+
+        }
+
+        public EFInterceptor(AWSXRayRecorder recorder, bool? collectSqlQueries = null) : base()
+        {
+            _recorder = recorder;
+            _collectSqlQueriesOverride = collectSqlQueries;
+        }
+
+        /// <summary>
+        /// Trace before executing reader.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandEventData"/>.</param>
+        /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
+        /// <returns>Result from <see cref="IInterceptor"/>.</returns>
+        public override InterceptionResult<DbDataReader> ReaderExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            ProcessBeginCommand(eventData);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        /// <summary>
+        /// Trace after executing reader.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandExecutedEventData"/>.</param>
+        /// <param name="result">Instance of <see cref="DbDataReader"/>.</param>
+        /// <returns>Instance of <see cref="DbDataReader"/>.</returns>
+        public override DbDataReader ReaderExecuted(DbCommand command, CommandExecutedEventData eventData, DbDataReader result)
+        {
+            ProcessEndCommand();
+            return base.ReaderExecuted(command, eventData, result);
+        }
+
+        /// <summary>
+        /// Trace before executing reader asynchronously.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandEventData"/>.</param>
+        /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
+        /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>Task representing the async operation.</returns>
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result, CancellationToken cancellationToken = default)
+        {
+            ProcessBeginCommand(eventData);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        /// <summary>
+        /// Trace after executing reader asynchronously.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandExecutedEventData"/>.</param>
+        /// <param name="result">Result from <see cref="DbDataReader"/>.</param>
+        /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>Task representing the async operation.</returns>
+        public override ValueTask<DbDataReader> ReaderExecutedAsync(DbCommand command, CommandExecutedEventData eventData, DbDataReader result, CancellationToken cancellationToken = default)
+        {
+            ProcessEndCommand();
+            return base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
+        }
+
+        /// <summary>
+        /// Trace after command fails.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandErrorEventData"/>.</param>
+        public override void CommandFailed(DbCommand command, CommandErrorEventData eventData)
+        {
+            ProcessCommandError(eventData);
+            base.CommandFailed(command, eventData);
+        }
+
+        /// <summary>
+        /// Trace after async command fails.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandErrorEventData"/>.</param>
+        /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>Task representing the async operation.</returns>
+        public override Task CommandFailedAsync(DbCommand command, CommandErrorEventData eventData, CancellationToken cancellationToken = default)
+        {
+            ProcessCommandError(eventData);
+            return base.CommandFailedAsync(command, eventData, cancellationToken);
+        }
+
+        /// <summary>
+        /// Trace before executing.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandEventData"/>.</param>
+        /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
+        /// <returns>Task representing the operation.</returns>
+        public override InterceptionResult<int> NonQueryExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
+        {
+            ProcessBeginCommand(eventData);
+            return base.NonQueryExecuting(command, eventData, result);
+        }
+
+        /// <summary>
+        /// Trace before executing asynchronously.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandEventData"/>.</param>
+        /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
+        /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>Task representing the async operation.</returns>
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+        {
+            ProcessBeginCommand(eventData);
+            return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        /// <summary>
+        /// Trace after executing.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandExecutedEventData"/>.</param>
+        /// <param name="result">Result as integer.</param>
+        /// <returns>Result as integer.</returns>
+        public override int NonQueryExecuted(DbCommand command, CommandExecutedEventData eventData, int result)
+        {
+            ProcessEndCommand();
+            return base.NonQueryExecuted(command, eventData, result);
+        }
+
+        /// <summary>
+        /// Trace after executing asynchronously.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandExecutedEventData"/>.</param>
+        /// <param name="result">Result as integer.</param>
+        /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>Task representing the async operation.</returns>
+        public override ValueTask<int> NonQueryExecutedAsync(DbCommand command, CommandExecutedEventData eventData, int result, CancellationToken cancellationToken = default)
+        {
+            ProcessEndCommand();
+            return base.NonQueryExecutedAsync(command, eventData, result, cancellationToken);
+        }
+
+        /// <summary>
+        /// Trace before executing scalar.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandEventData"/>.</param>
+        /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
+        /// <returns>Result from <see cref="IInterceptor"/>.</returns>
+        public override InterceptionResult<object> ScalarExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<object> result)
+        {
+            ProcessBeginCommand(eventData);
+            return base.ScalarExecuting(command, eventData, result);
+        }
+
+        /// <summary>
+        /// Trace before executing scalar asynchronously.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandEventData"/>.</param>
+        /// <param name="result">Result from <see cref="IInterceptor"/>.</param>
+        /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>Task representing the async operation.</returns>
+        public override ValueTask<InterceptionResult<object>> ScalarExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<object> result, CancellationToken cancellationToken = default)
+        {
+            ProcessBeginCommand(eventData);
+            return base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        /// <summary>
+        /// Trace after executing scalar.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandExecutedEventData"/>.</param>
+        /// <param name="result">Result object.</param>
+        /// <returns>Result object.</returns>
+        public override object ScalarExecuted(DbCommand command, CommandExecutedEventData eventData, object result)
+        {
+            ProcessEndCommand();
+            return base.ScalarExecuted(command, eventData, result);
+        }
+
+        /// <summary>
+        /// Trace after executing scalar asynchronously.
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <param name="eventData">Instance of <see cref="CommandExecutedEventData"/>.</param>
+        /// <param name="result">Result object.</param>
+        /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>Task representing the async operation.</returns>
+        public override ValueTask<object> ScalarExecutedAsync(DbCommand command, CommandExecutedEventData eventData, object result, CancellationToken cancellationToken = default)
+        {
+            ProcessEndCommand();
+            return base.ScalarExecutedAsync(command, eventData, result, cancellationToken);
+        }
+
+        private void ProcessBeginCommand(CommandEventData eventData)
+        {
+            Entity entity = null;
+            try
+            {
+                entity = _recorder.GetEntity();
+            }
+            catch (EntityNotAvailableException e)
+            {
+                _recorder.TraceContext.HandleEntityMissing(_recorder, e, "Cannot get entity while processing start of Entity Framework command.");
+            }
+
+            _recorder.BeginSubsegment(BuildSubsegmentName(eventData.Command));
+            _recorder.SetNamespace("remote");
+            CollectSqlInformation(eventData);
+        }
+
+        private void ProcessEndCommand()
+        {
+            Entity entity = null;
+            try
+            {
+                entity = _recorder.GetEntity();
+            }
+            catch (EntityNotAvailableException e)
+            {
+                _recorder.TraceContext.HandleEntityMissing(_recorder, e, "Cannot get entity while processing end of Entity Framework command.");
+                return;
+            }
+
+            _recorder.EndSubsegment();
+        }
+
+        private void ProcessCommandError(CommandErrorEventData eventData)
+        {
+            Entity subsegment;
+            try
+            {
+                subsegment = _recorder.GetEntity();
+            }
+            catch (EntityNotAvailableException e)
+            {
+                _recorder.TraceContext.HandleEntityMissing(_recorder, e, "Cannot get entity while processing failure of Entity Framework command.");
+                return;
+            }
+
+            subsegment.AddException(eventData.Exception);
+
+            _recorder.EndSubsegment();
+        }
+
+        /// <summary>
+        /// Records the SQL information on the current subsegment,
+        /// </summary>
+        protected virtual void CollectSqlInformation(CommandEventData eventData)
+        {
+            // Get database type from DbContext
+            string databaseType = EFUtil.GetDataBaseType(eventData.Context);
+            _recorder.AddSqlInformation("database_type", databaseType);
+
+            _recorder.AddSqlInformation("database_version", eventData.Command.Connection.ServerVersion);
+
+            DbConnectionStringBuilder connectionStringBuilder = new DbConnectionStringBuilder
+            {
+                ConnectionString = eventData.Command.Connection.ConnectionString
+            };
+
+            // Remove sensitive information from connection string
+            connectionStringBuilder.Remove("Password");
+
+            // Do a pre-check for UserID since in the case of TrustedConnection, a UserID may not be available.
+            var user_id = EFUtil.GetUserId(connectionStringBuilder);
+            if (user_id != null)
+            {
+                _recorder.AddSqlInformation("user", user_id.ToString());
+            }
+
+            _recorder.AddSqlInformation("connection_string", connectionStringBuilder.ToString());
+
+            if (ShouldCollectSqlText())
+            {
+                _recorder.AddSqlInformation("sanitized_query", eventData.Command.CommandText);
+            }
+        }
+
+        /// <summary>
+        /// Builds the name of the subsegment in the format database@datasource
+        /// </summary>
+        /// <param name="command">Instance of <see cref="DbCommand"/>.</param>
+        /// <returns>Returns the formed subsegment name as a string.</returns>
+        private string BuildSubsegmentName(DbCommand command)
+            => command.Connection.Database + "@" + EFUtil.RemovePortNumberFromDataSource(command.Connection.DataSource);
+
+        private bool ShouldCollectSqlText()
+            => _collectSqlQueriesOverride ?? _recorder.XRayOptions.CollectSqlQueries;
+    }
+}

--- a/sdk/src/Handlers/EntityFramework5/EFUtil.cs
+++ b/sdk/src/Handlers/EntityFramework5/EFUtil.cs
@@ -1,0 +1,120 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="EFUtil.cs" company="Amazon.com">
+//      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+//      Licensed under the Apache License, Version 2.0 (the "License").
+//      You may not use this file except in compliance with the License.
+//      A copy of the License is located at
+//
+//      http://aws.amazon.com/apache2.0
+//
+//      or in the "license" file accompanying this file. This file is distributed
+//      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//      express or implied. See the License for the specific language governing
+//      permissions and limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Amazon.XRay.Recorder.Handlers.EntityFramework
+{
+    /// <summary>
+    /// Utilities for EFInterceptor
+    /// </summary>
+    public static class EFUtil
+    {
+        private static readonly string DefaultDatabaseType = "EntityFrameworkCore";
+
+        private static readonly string[] UserIdFormatOptions = { "user id", "username", "user", "userid" }; // case insensitive
+
+        // Some database providers may not support Entity Framework Core 3.0 and above now
+        // https://docs.microsoft.com/en-us/ef/core/providers/?tabs=dotnet-core-cli
+        private static readonly Dictionary<string, string> DatabaseTypes = new Dictionary<string, string>()
+        {
+            { "Microsoft.EntityFrameworkCore.SqlServer" , "sqlserver" },
+            { "Microsoft.EntityFrameworkCore.Sqlite" , "sqlite" },
+            { "Npgsql.EntityFrameworkCore.PostgreSQL" , "postgresql" },
+            { "Pomelo.EntityFrameworkCore.MySql" , "mysql" },
+            { "FirebirdSql.EntityFrameworkCore.Firebird" , "firebirdsql" },
+
+            { "Microsoft.EntityFrameworkCore.InMemory" , "inmemory" },
+            { "Microsoft.EntityFrameworkCore.Cosmos" , "cosmosdb" },
+            { "Devart.Data.MySql.EFCore" , "mysql" },
+            { "Devart.Data.Oracle.EFCore" , "oracle" },
+            { "Devart.Data.PostgreSql.EFCore" , "postgresql" },
+            { "Devart.Data.SQLite.EFCore" , "sqlite" },
+            { "FileContextCore" , "filecontextcore" },
+            { "EntityFrameworkCore.Jet" , "jet" },
+            { "EntityFrameworkCore.SqlServerCompact35" , "sqlservercompact35" },
+            { "EntityFrameworkCore.SqlServerCompact40" , "sqlservercompact40" },
+            { "Teradata.EntityFrameworkCore" , "teradata" },
+            { "EntityFrameworkCore.FirebirdSql" , "firebirdsql" },
+            { "EntityFrameworkCore.OpenEdge" , "openedge" },
+            { "MySql.Data.EntityFrameworkCore" , "mysql" },
+            { "Oracle.EntityFrameworkCore" , "oracle" },
+            { "IBM.EntityFrameworkCore" , "ibm" },
+            { "IBM.EntityFrameworkCore-lnx" , "ibm" },
+            { "IBM.EntityFrameworkCore-osx" , "ibm" },
+            { "Pomelo.EntityFrameworkCore.MyCat" , "mycat" }
+        };
+
+        private static readonly Regex _portNumberRegex = new Regex(@"[,|:]\d+$");
+
+        /// <summary>
+        /// Extract database_type from <see cref="DbContext"/>.
+        /// </summary>
+        /// <param name="context">Instance of <see cref="DbContext"/>.</param>
+        /// <returns>Type of database.</returns>
+        public static string GetDataBaseType(DbContext context)
+        {
+            string databaseProvider = context?.Database?.ProviderName;
+
+            // Need to check if the context and its following parameter is null or not to avoid exception
+            if (string.IsNullOrEmpty(databaseProvider))
+            {
+                return DefaultDatabaseType;
+            }
+
+            string value = null;
+
+            if (DatabaseTypes.TryGetValue(databaseProvider, out value))
+            {
+                return value;
+            }
+
+            return databaseProvider;
+        }
+
+        /// <summary>
+        /// Extract user id from <see cref="DbConnectionStringBuilder"/>.
+        /// </summary>
+        /// <param name="builder">Instance of <see cref="DbConnectionStringBuilder"/>.</param>
+        /// <returns></returns>
+        public static object GetUserId(DbConnectionStringBuilder builder)
+        {
+            object value = null;
+            foreach (string key in UserIdFormatOptions)
+            {
+                if (builder.TryGetValue(key, out value))
+                {
+                    break;
+                }
+            }
+            return value;
+        }
+
+        /// <summary>
+        /// Removes the port number from data source.
+        /// </summary>
+        /// <param name="dataSource">The data source.</param>
+        /// <returns>The data source string with port number removed.</returns>
+        public static string RemovePortNumberFromDataSource(string dataSource)
+        {
+            return _portNumberRegex.Replace(dataSource, string.Empty);
+        }
+    }
+}

--- a/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
+++ b/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -34,6 +34,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.0|AnyCPU'">
     <NoWarn>0618;1701;1702;1705</NoWarn>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <NoWarn>0618;1701;1702;1705</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|AnyCPU'">
+    <NoWarn>0618;1701;1702;1705</NoWarn>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.5.1.23" />
@@ -43,18 +52,26 @@
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.0.26" />
     <PackageReference Include="Moq" Version="4.7.137" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0">
     </PackageReference>
 
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0">
     </PackageReference>
 
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.0.0" />
     <ProjectReference Include="..\..\src\Handlers\EntityFramework\AWSXRayRecorder.Handlers.EntityFramework.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.0" />
+    <ProjectReference Include="..\..\src\Handlers\EntityFramework5\AWSXRayRecorder.Handlers.EntityFramework5.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
@@ -75,7 +92,7 @@
     <Compile Remove="Tools\MockHttpRequest.cs" />
     <Compile Remove="Tools\MockHttpRequestFactory.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <Compile Remove="Tools\MockHttpRequestNetcore.cs" />
     <Compile Remove="Tools\MockHttpRequestFactoryNetcore.cs" />
     <Compile Remove="Tools\CustomWebResponse.cs" />

--- a/sdk/test/UnitTests/EfCoreTests.cs
+++ b/sdk/test/UnitTests/EfCoreTests.cs
@@ -95,7 +95,7 @@ namespace Amazon.XRay.Recorder.UnitTests
 
             try
             {
-                context.Database.ExecuteSqlCommand("Select * From FakeTable"); // A false sql command which results in 'no such table: FakeTable' exception
+                context.Database.ExecuteSqlRaw("Select * From FakeTable"); // A false sql command which results in 'no such table: FakeTable' exception
             }
             catch
             {

--- a/sdk/test/UnitTests/JsonSegmentMarshallerTest.cs
+++ b/sdk/test/UnitTests/JsonSegmentMarshallerTest.cs
@@ -190,8 +190,11 @@ namespace Amazon.XRay.Recorder.UnitTests
                 var filePath = trace.GetFrame(0).GetFileName().Replace("\\", "\\\\");
                 var line = new StackTrace(e, true).GetFrame(0).GetFileLineNumber();
                 var workingDirectory = Directory.GetCurrentDirectory().Replace("\\", "\\\\");
+#if NETCOREAPP3_1
+                var expected = "{\"format\":\"json\",\"version\":1}\n{\"id\":\"1111111111111111\",\"start_time\":0,\"end_time\":0,\"name\":\"test\",\"fault\":true,\"cause\":{\"working_directory\":\"" + workingDirectory + "\",\"exceptions\":[{\"id\":\"" + subsegment.Cause.ExceptionDescriptors[0].Id + "\",\"message\":\"Value cannot be null. (Parameter 'value')\",\"type\":\"ArgumentNullException\",\"remote\":false,\"stack\":[{\"path\":\"" + filePath + "\",\"line\":" + line + ",\"label\":\"Amazon.XRay.Recorder.UnitTests.JsonSegmentMarshallerTest.TestMarshallAddException\"}]}]}}";
+#else
                 var expected = "{\"format\":\"json\",\"version\":1}\n{\"id\":\"1111111111111111\",\"start_time\":0,\"end_time\":0,\"name\":\"test\",\"fault\":true,\"cause\":{\"working_directory\":\"" + workingDirectory + "\",\"exceptions\":[{\"id\":\"" + subsegment.Cause.ExceptionDescriptors[0].Id + "\",\"message\":\"Value cannot be null." + Environment.NewLine.Replace("\r", @"\r").Replace("\n", @"\n") + "Parameter name: value\",\"type\":\"ArgumentNullException\",\"remote\":false,\"stack\":[{\"path\":\"" + filePath + "\",\"line\":" + line + ",\"label\":\"Amazon.XRay.Recorder.UnitTests.JsonSegmentMarshallerTest.TestMarshallAddException\"}]}]}}";
-
+#endif
                 Assert.AreEqual(expected, actual);
             }
         }


### PR DESCRIPTION
This is another possible solution to #174

In this solution, we add a new NuGet package named `AWSXRayRecorder.Handlers.EntityFramework5` with support for EF5. This way, both packages (the one with support for EF3.1 and the one with support for EF5) can be maintained separately in the same code line.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.