### PR TITLE
Workflow fix

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -21,7 +21,7 @@ jobs:
                 
         steps:
         - name: Checkout repository
-        - uses: actions/checkout@v2
+          uses: actions/checkout@v2
           
         - name: Install dependencies
           run: dotnet restore sdk/AWSXRayRecorder.sln --locked-mode

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -23,6 +23,9 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v2
           
+        - name: Clean solution
+          run: dotnet clean sdk/AWSXRayRecorder.sln --configuration Release && dotnet nuget locals all --clear
+        
         - name: Install dependencies
           run: dotnet restore sdk/AWSXRayRecorder.sln --locked-mode
           


### PR DESCRIPTION
*Description of changes:*
Noticed the workflow failure on [this](https://github.com/aws/aws-xray-sdk-dotnet/actions/runs/579560564) run because there was an `-` before `uses` key. Removing the `-` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
