### PR TITLE
Run test on ubuntu

### DIFF
--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -13,11 +13,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [windows-latest,ubuntu-latest]
-                version: [net452,netcoreapp2.0]
-                exclude:
-                  - os: ubuntu-latest
-                    version: net452
+                os: [ubuntu-latest]
+                version: [netcoreapp2.0]
 
         steps:
           - name: Checkout repository


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Since `continuous-monitoring` workflow focuses on running distribution tests (if nuget package is available for download) therefore running smoke tests only on `ubuntu` should be good enough.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
