### PR TITLE
Finding the same exception in different subsegments should reuse the same cause id

### DIFF
--- a/sdk/src/Core/Strategies/DefaultExceptionSerializationStrategy.cs
+++ b/sdk/src/Core/Strategies/DefaultExceptionSerializationStrategy.cs
@@ -154,6 +154,7 @@ namespace Amazon.XRay.Recorder.Core.Strategies
             if (existingDescriptor != null)
             {
                 ex.Cause = existingDescriptor.Id != null ? existingDescriptor.Id : existingDescriptor.Cause;
+                ex.Exception = existingDescriptor.Exception; // pass the exception of the cause so that this reference can be found if the same exception is thrown again
                 ex.Id = null;  // setting this to null since, cause is already populated with reference to downstream exception
                 result.Add(ex);
                 return result;


### PR DESCRIPTION
*Issue #, if available:*
#209

*Description of changes:*
Associate the existing descriptor's exception with the new descriptor so that it can be used in other subsegments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
