### PR TITLE
Add netcoreapp3.1 target framework

### DIFF
--- a/sdk/AWSXRayRecorder.nuspec
+++ b/sdk/AWSXRayRecorder.nuspec
@@ -30,6 +30,19 @@
         <dependency id="AWSXRayRecorder.Handlers.SqlServer" version="2.7.3" />
         <dependency id="AWSXRayRecorder.Handlers.System.Net" version="2.7.3" />
       </group>
+      <group targetFramework=".NETCoreApp3.1">
+        <dependency id="AWSXRayRecorder.Core" version="2.10.1" />
+        <dependency id="AWSXRayRecorder.Handlers.AspNetCore" version="2.7.3" />
+        <dependency id="AWSXRayRecorder.Handlers.AwsSdk" version="2.8.3" />
+        <dependency id="AWSXRayRecorder.Handlers.EntityFramework" version="1.1.1" />
+        <dependency id="AWSXRayRecorder.Handlers.SqlServer" version="2.7.3" />
+        <dependency id="AWSXRayRecorder.Handlers.System.Net" version="2.7.3" />
+      </group>
     </dependencies>
+    <frameworkReferences>
+      <group targetFramework=".NETCoreApp3.1">
+        <frameworkReference name="Microsoft.AspNetCore.App" />
+      </group>
+    </frameworkReferences>
   </metadata>
 </package>

--- a/sdk/src/Core/AWSXRayRecorder.Core.csproj
+++ b/sdk/src/Core/AWSXRayRecorder.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -46,7 +46,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
   </ItemGroup>
-  
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' != 'net45'">
     <Compile Remove="Internal\Context\CallContextContainer.net45.cs" />
     <Compile Remove="Internal\Context\HybridContextContainer.net45.cs" />
@@ -54,7 +58,7 @@
     <Compile Remove="AWSXRayRecorder.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Compile Remove="Internal\Context\AsyncLocalContextContainer.netstandard.cs" />
     <Compile Remove="Internal\Context\LambdaContextContainer.netstandard.cs" />
     <Compile Remove="Internal\Utils\AppSettings.netcore.cs" />

--- a/sdk/src/Handlers/AspNetCore/AWSXRayRecorder.Handlers.AspNetCore.csproj
+++ b/sdk/src/Handlers/AspNetCore/AWSXRayRecorder.Handlers.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -28,9 +28,13 @@
     <NoWarn>1701;1702;1705;1591;1587;1573;1572</NoWarn>
   </PropertyGroup>
   
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/test/IntegrationTests/AWSXRayRecorder.IntegrationTests.csproj
+++ b/sdk/test/IntegrationTests/AWSXRayRecorder.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>

--- a/sdk/test/SmokeTests/AWSXRayRecorder.SmokeTests.csproj
+++ b/sdk/test/SmokeTests/AWSXRayRecorder.SmokeTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>

--- a/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
+++ b/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -35,6 +35,15 @@
     <NoWarn>0618;1701;1702;1705</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <NoWarn>0618;1701;1702;1705</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|AnyCPU'">
+    <NoWarn>0618;1701;1702;1705</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.5.1.23" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.1.1" />
@@ -54,6 +63,11 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Data.SQLite" Version="1.0.113.7" />
@@ -77,7 +91,7 @@
     <Compile Remove="Tools\MockHttpRequestFactory.cs" />
     <Compile Remove="EF6Tests.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.113" />
     <Compile Remove="Tools\MockHttpRequestNetcore.cs" />

--- a/sdk/test/UnitTests/JsonSegmentMarshallerTest.cs
+++ b/sdk/test/UnitTests/JsonSegmentMarshallerTest.cs
@@ -114,7 +114,7 @@ namespace Amazon.XRay.Recorder.UnitTests
 
         public object SyncFunction(object obj) => obj;
         public void SyncAction(object obj) { return; }
-        public async Task<object> AsyncFunction(object obj) => obj;
+        public Task<object> AsyncFunction(object obj) => Task.FromResult(obj);
 
         [TestMethod]
         public void TestMarshallSimpleSegment()
@@ -190,7 +190,12 @@ namespace Amazon.XRay.Recorder.UnitTests
                 var filePath = trace.GetFrame(0).GetFileName().Replace("\\", "\\\\");
                 var line = new StackTrace(e, true).GetFrame(0).GetFileLineNumber();
                 var workingDirectory = Directory.GetCurrentDirectory().Replace("\\", "\\\\");
+
+#if NETCOREAPP3_1_OR_GREATER
+                var expected = "{\"format\":\"json\",\"version\":1}\n{\"id\":\"1111111111111111\",\"start_time\":0,\"end_time\":0,\"name\":\"test\",\"fault\":true,\"cause\":{\"working_directory\":\"" + workingDirectory + "\",\"exceptions\":[{\"id\":\"" + subsegment.Cause.ExceptionDescriptors[0].Id + "\",\"message\":\"Value cannot be null. (Parameter 'value')\",\"type\":\"ArgumentNullException\",\"remote\":false,\"stack\":[{\"path\":\"" + filePath + "\",\"line\":" + line + ",\"label\":\"Amazon.XRay.Recorder.UnitTests.JsonSegmentMarshallerTest.TestMarshallAddException\"}]}]}}";
+#else
                 var expected = "{\"format\":\"json\",\"version\":1}\n{\"id\":\"1111111111111111\",\"start_time\":0,\"end_time\":0,\"name\":\"test\",\"fault\":true,\"cause\":{\"working_directory\":\"" + workingDirectory + "\",\"exceptions\":[{\"id\":\"" + subsegment.Cause.ExceptionDescriptors[0].Id + "\",\"message\":\"Value cannot be null." + Environment.NewLine.Replace("\r", @"\r").Replace("\n", @"\n") + "Parameter name: value\",\"type\":\"ArgumentNullException\",\"remote\":false,\"stack\":[{\"path\":\"" + filePath + "\",\"line\":" + line + ",\"label\":\"Amazon.XRay.Recorder.UnitTests.JsonSegmentMarshallerTest.TestMarshallAddException\"}]}]}}";
+#endif
 
                 Assert.AreEqual(expected, actual);
             }


### PR DESCRIPTION
Add a target framework moniker for .NET Core 3.1.

## Context

We have a number of .NET Core 3.1 Lambda functions that use the X-Ray recorder, and due to the only Target Framework Moniker for .NET Core being `netstandard2.0`, it will publish the application with all of the relevant binary files, such as `Microsoft.AspNetCore.Http.dll`.

![image](https://user-images.githubusercontent.com/1439341/137276506-4dcef81c-6c1a-4ad5-880a-ec7b11744229.png)

However, in .NET Core 3.0 and later, these binaries are no longer published as NuGet packages, and instead are included in the ASP.NET Core shared framework. This means that versions of the binary greater than [2.2.2](https://www.nuget.org/packages/Microsoft.AspNetCore.Http/2.2.2) are not available to be upgraded to explicitly, leading to "old" binaries that don't need to be used being published with the application.

As all versions of ASP.NET Core earlier than 3.1 are now out-of-support, any security vulnerabilities in these tools get flagged when using security scanning tools such as Nexus Sonatype.

![image](https://user-images.githubusercontent.com/1439341/137277227-b277e289-103c-484c-9169-d1a36193ab65.png)

As there are no "non-vulnerable" versions of the dependency available from NuGet (because they're in the shared framework), it is not possible to upgrade to a .NET Core 3.1 version of this dependency to resolve the issue.

This PR attempts to resolve this issue by adding a `netcoreapp3.1` Target Framework Moniker so that the relevant recorder libraries understand the ASP.NET Core Framework, and will not include the relevant binaries as part of the deployment package.
