### PR TITLE
Update .netappcore version for smoke tests

### DIFF
--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -14,7 +14,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                version: [netcoreapp2.0]
+                version: [netcoreapp3.1.4]
 
         steps:
           - name: Checkout repository

--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -14,7 +14,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                version: [netcoreapp3.1.4]
+                version: [netcoreapp3.1]
 
         steps:
           - name: Checkout repository

--- a/sdk/test/SmokeTests/AWSXRayRecorder.SmokeTests.csproj
+++ b/sdk/test/SmokeTests/AWSXRayRecorder.SmokeTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0;netcoreapp3.1;netcoreapp3.1.4</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>

--- a/sdk/test/SmokeTests/AWSXRayRecorder.SmokeTests.csproj
+++ b/sdk/test/SmokeTests/AWSXRayRecorder.SmokeTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0;netcoreapp3.1;netcoreapp3.1.4</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>


### PR DESCRIPTION
*Issue #, if available:*
Today, Github actions have started following this error in continuous-monitoring workflow. I could not find any official docs on weather Github actions has stopped supporting on `.netappcore2.0` but I think updating to `.netappcore3.1` should fix the issue.

```
Testhost process exited with error: It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '2.0.0' (x64) was not found.
  - The following frameworks were found:
      3.1.4 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
      3.1.6 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
      3.1.[20](https://github.com/aws/aws-xray-sdk-dotnet/runs/5279266653?check_suite_focus=true#step:6:20) at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
      3.1.[22](https://github.com/aws/aws-xray-sdk-dotnet/runs/5279266653?check_suite_focus=true#step:6:22) at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
      5.0.4 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
      5.0.9 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
      5.0.14 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
      6.0.2 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
You can resolve the problem by installing the specified framework and/or SDK.
The specified framework can be found at:
  - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=2.0.0&arch=x64&rid=ubuntu.20.04-x64
```

*Description of changes:*
Update `.netcoreapp` to `3.1` version to fix monitoring workflow.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
