### PR TITLE
Use GitHub workflow for CI on PRs and master builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: Continuous Build
 on:
     push:
         branches:
-            - fix_ci
+            - master
     pull_request:
         branches:
-            - fix_ci
+            - master
 
 jobs:
     build-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                version: [net452,netcoreapp2.0,netcoreapp3.1]
+                version: [net452, netcoreapp2.0, netcoreapp3.1]
 
         steps:
         - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,8 @@ jobs:
           run: dotnet build sdk/AWSXRayRecorder.sln --configuration Release --no-restore
 
         - name: Run tests
-          run: dotnet test sdk/test/UnitTests/bin/Release/${{matrix.version}}/AWSXRayRecorder.UnitTests.dll --configuration Release --no-build --logger:"console;verbosity=detailed"
+          run: >-
+            dotnet test sdk/test/UnitTests/bin/Release/${{matrix.version}}/AWSXRayRecorder.UnitTests.dll
+            --configuration Release
+            --no-build
+            --logger "console;verbosity=detailed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: Continuous Build
+
+on:
+    push:
+        branches:
+            - fix_ci
+    pull_request:
+        branches:
+            - fix_ci
+
+jobs:
+    build-test:
+        runs-on: windows-latest
+
+        env:
+            DOTNET_MULTILEVEL_LOOKUP: 1
+
+        strategy:
+            fail-fast: false
+            matrix:
+                version: [net452,netcoreapp2.0,netcoreapp3.1]
+
+        steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+
+        - uses: actions/setup-dotnet@v1
+          with:
+            dotnet-version: '2.0.x'
+
+        - uses: actions/setup-dotnet@v1
+          with:
+            dotnet-version: '3.1.x'
+
+        - name: Install dependencies
+          run: dotnet restore sdk/AWSXRayRecorder.sln
+
+        - name: Build solution
+          run: dotnet build sdk/AWSXRayRecorder.sln --configuration Release --no-restore
+
+        - name: Run tests
+          run: dotnet test sdk/test/UnitTests/bin/Release/${{matrix.version}}/AWSXRayRecorder.UnitTests.dll --configuration Release --no-build --logger:"console;verbosity=detailed"


### PR DESCRIPTION
*Issue:* Our AppVeyor CI has been a hit or miss lately. Although it does [run](https://ci.appveyor.com/project/yogiraj07/aws-xray-sdk-dotnet-nd0el/builds/42783210), the CI is not able to post results back to Github PR. As a result the PRs are not blocked even if the AppVeyor CI fails. This is dangerous as we are flying blind. This is good point to use native GH workflows to run CI and we don't have to maintain AppVeyor CI anymore.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
