### PR TITLE
Remove obsolete netcoreapp2.0 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                version: [net452, netcoreapp2.0, netcoreapp3.1]
+                version: [net452, netcoreapp3.1]
 
         steps:
         - name: Checkout repository
@@ -41,6 +41,4 @@ jobs:
         - name: Run tests
           run: >-
             dotnet test sdk/test/UnitTests/bin/Release/${{matrix.version}}/AWSXRayRecorder.UnitTests.dll
-            --configuration Release
-            --no-build
             --logger "console;verbosity=detailed"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: '1.0.{build}'
-image: Visual Studio 2019
+image: Visual Studio 2022
 init:
   # Good practise, because Windows line endings are different from Unix/Linux ones
   - cmd: git config --global core.autocrlf true

--- a/sdk/src/Core/AWSXRayRecorder.Core.csproj
+++ b/sdk/src/Core/AWSXRayRecorder.Core.csproj
@@ -38,13 +38,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.25.1" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.8.6" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/sdk/src/Handlers/EntityFramework/AWSXRayRecorder.Handlers.EntityFramework.csproj
+++ b/sdk/src/Handlers/EntityFramework/AWSXRayRecorder.Handlers.EntityFramework.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
     <Compile Remove="AWSXRayInterceptorExtensions.cs" />
     <Compile Remove="EFInterceptor.cs" />
   </ItemGroup>

--- a/sdk/test/IntegrationTests/AWSXRayRecorder.IntegrationTests.csproj
+++ b/sdk/test/IntegrationTests/AWSXRayRecorder.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -13,17 +13,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.5.1.23" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.1.1" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.5.0.25" />
-    <PackageReference Include="AWSSDK.S3" Version="3.5.3.1" />
-    <PackageReference Include="AWSSDK.XRay" Version="3.5.2.16" />
-    <PackageReference Include="Moq" Version="4.7.137" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.8.6" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.7" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.8.4" />
+    <PackageReference Include="AWSSDK.XRay" Version="3.7.0.132" />
+    <PackageReference Include="Moq" Version="4.17.2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\AWSXRayRecorder.Core.csproj" />

--- a/sdk/test/SmokeTests/AWSXRayRecorder.SmokeTests.csproj
+++ b/sdk/test/SmokeTests/AWSXRayRecorder.SmokeTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -17,9 +17,9 @@
 
   <ItemGroup>
     <PackageReference Include="AWSXRayRecorder.Core" Version="*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Moq" Version="4.7.137" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
   </ItemGroup>
 </Project>

--- a/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
+++ b/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -12,7 +12,7 @@
     <AssemblyOriginatorKeyFile>../../../buildtools/local-development.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  
+
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net452|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <NoWarn>0618;1701;1702;1705</NoWarn>
@@ -26,15 +26,6 @@
     <DefineConstants>NET45</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-    <NoWarn>0618;1701;1702;1705</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.0|AnyCPU'">
-    <NoWarn>0618;1701;1702;1705</NoWarn>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <NoWarn>0618;1701;1702;1705</NoWarn>
@@ -45,24 +36,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.5.1.23" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.1.1" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.5.0.25" />
-    <PackageReference Include="AWSSDK.S3" Version="3.5.3.1" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.0.26" />
-    <PackageReference Include="Moq" Version="4.7.137" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0">
-    </PackageReference>
-
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0">
-    </PackageReference>
-
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.0.0" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.8.6" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.7" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.8.4" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.32" />
+    <PackageReference Include="Moq" Version="4.17.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
@@ -70,10 +49,10 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Data.SQLite" Version="1.0.113.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.115.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\AWSXRayRecorder.Core.csproj" />
@@ -93,7 +72,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.113" />
+    <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.115.5" />
     <Compile Remove="Tools\MockHttpRequestNetcore.cs" />
     <Compile Remove="Tools\MockHttpRequestFactoryNetcore.cs" />
     <Compile Remove="Tools\CustomWebResponse.cs" />


### PR DESCRIPTION
*Description of changes:*

- Removing obsolete netcoreapp2.0 runtime
- Updating AWSSDK to 3.7.x
- Updating testing references

Extracted work from #223 to reduce amount of change in single PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
