### PR TITLE
Removed blocking call which was producing deadlocks from EC2Plugin.

### DIFF
--- a/sdk/src/Core/Plugins/EC2Plugin.cs
+++ b/sdk/src/Core/Plugins/EC2Plugin.cs
@@ -17,9 +17,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.IO;
+using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
+using System.Text;
 using Amazon.Runtime.Internal.Util;
 using ThirdParty.LitJson;
 
@@ -31,7 +32,6 @@ namespace Amazon.XRay.Recorder.Core.Plugins
     public class EC2Plugin : IPlugin
     {
         private static readonly Logger _logger = Logger.GetLogger(typeof(EC2Plugin));
-        private readonly HttpClient _client = new HttpClient();
         const string metadata_base_url = "http://169.254.169.254/latest/";
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace Amazon.XRay.Recorder.Core.Plugins
             {
                 Dictionary<string, string> header = new Dictionary<string, string>(1);
                 header.Add("X-aws-ec2-metadata-token-ttl-seconds", "60");
-                token = DoRequest(metadata_base_url + "api/token", HttpMethod.Put, header).Result;
+                token = DoRequest(metadata_base_url + "api/token", HttpMethod.Put, header);
             }
             catch (Exception)
             {
@@ -109,7 +109,7 @@ namespace Amazon.XRay.Recorder.Core.Plugins
                     headers.Add("X-aws-ec2-metadata-token", token);
                 }
                 string identity_doc_url = metadata_base_url + "dynamic/instance-identity/document";
-                string doc_string = DoRequest(identity_doc_url, HttpMethod.Get, headers).Result;
+                string doc_string = DoRequest(identity_doc_url, HttpMethod.Get, headers);
                 return ParseMetadata(doc_string);
             }
             catch (Exception)
@@ -120,26 +120,34 @@ namespace Amazon.XRay.Recorder.Core.Plugins
         }
 
 
-        protected virtual async Task<string> DoRequest(string url, HttpMethod method, Dictionary<string, string> headers = null)
+        protected virtual string DoRequest(string url, HttpMethod method, Dictionary<string, string> headers = null)
         {
-            HttpRequestMessage request = new HttpRequestMessage(method, url);
+            var httpWebRequest = WebRequest.CreateHttp(url);
+
+            httpWebRequest.Timeout = 2000; // 2 seconds timeout
+            httpWebRequest.Method = method.Method;
+
             if (headers != null)
             {
                 foreach (var item in headers)
                 {
-                    request.Headers.Add(item.Key, item.Value);
+                    httpWebRequest.Headers.Add(item.Key, item.Value);
                 }
             }
 
-            _client.Timeout = TimeSpan.FromSeconds(2); // 2 seconds timeout
-            HttpResponseMessage response = await _client.SendAsync(request);
-            if (response.IsSuccessStatusCode)
+            using(var response = (HttpWebResponse)httpWebRequest.GetResponse())
             {
-                return await response.Content.ReadAsStringAsync();
-            }
-            else
-            {
-                throw new Exception("Unable to complete the request successfully");
+                if (response.StatusCode < HttpStatusCode.OK || (int)response.StatusCode > 299)
+                {
+                    throw new Exception("Unable to complete the request successfully");
+                }
+
+                var encoding = Encoding.GetEncoding(response.ContentEncoding);
+
+                using (var streamReader = new StreamReader(response.GetResponseStream(), encoding))
+                {
+                    return streamReader.ReadToEnd();
+                }
             }
         }
 

--- a/sdk/test/UnitTests/TestEC2Plugin.cs
+++ b/sdk/test/UnitTests/TestEC2Plugin.cs
@@ -119,7 +119,7 @@ namespace Amazon.XRay.Recorder.UnitTests
             _failV2 = failV2;
         }
 
-        protected override Task<string> DoRequest(string url, HttpMethod method, Dictionary<string, string> headers = null)
+        protected override string DoRequest(string url, HttpMethod method, Dictionary<string, string> headers = null)
         {
             if (_failV2 && url == "http://169.254.169.254/latest/api/token")
             {
@@ -127,7 +127,7 @@ namespace Amazon.XRay.Recorder.UnitTests
             }
             else if (!_failV2 && url == "http://169.254.169.254/latest/api/token")
             {
-                return Task.FromResult("dummyTokenfromferg");
+                return "dummyTokenfromferg";
             }
             else if (_failV1)
             {
@@ -138,12 +138,12 @@ namespace Amazon.XRay.Recorder.UnitTests
             if (headers == null) // for v1 endpoint request
             {
                 meta_string = "{\"availabilityZone\" : \"us-west-2a\", \"imageId\" : \"ami-03cca83dd001d4d11\", \"instanceId\" : \"i-07a181803de94c477\", \"instanceType\" : \"t2.xlarge\"}";
-                return Task.FromResult(meta_string);
+                return meta_string;
             }
             else
             { // for v2 endpoint
                 meta_string = "{\"availabilityZone\" : \"us-east-2a\", \"imageId\" : \"ami-03cca83dd001d4666\", \"instanceId\" : \"i-07a181803de94c666\", \"instanceType\" : \"t3.xlarge\"}";
-                return Task.FromResult(meta_string);
+                return meta_string;
             }
         }
 


### PR DESCRIPTION
The calls to `Task.Result` in `GetToken` and `GetMetadata` are blocking and can result in deadlocks if either the response or the timeout are handled on the same thread. See here for a similar example and explanation.

> "Don’t block on Tasks; use async all the way down."
https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html

One option here could have been to replace the calls to `Result` with the `async` and `await` keywords, but that would have required that modifications to the `IPlugin` interface and its consumers. That might be something that should be considered, but given that the call to `Result` was already making this code synchronous, nothing will be lost by using a synchronous API as an immediate fix.

There is a synchronous `Send` method which has been added to `HttpClient` in .Net 5 but it is not available in any of the targeted frameworks - .Net Framework 4.5, .Net Core 3.1 or .Net Standard 2.0.

 Although `HttpWebRequest` is not recommended for new development, it does offer a synchronous alternative and is the option that I have used in this pull request.

> "We don't recommend that you use `HttpWebRequest` for new development. Instead, use the [System.Net.Http.HttpClient](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?view=netframework-4.5) class."
https://docs.microsoft.com/en-us/dotnet/api/system.net.httpwebrequest?view=netframework-4.5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
