### PR TITLE
Resolve CA2200 by rethrowing exception to preserve stack details

### DIFF
--- a/sdk/test/UnitTests/CauseTest.cs
+++ b/sdk/test/UnitTests/CauseTest.cs
@@ -129,7 +129,7 @@ namespace Amazon.XRay.Recorder.UnitTests
                     {
                         recorder.AddException(e);
                         recorder.EndSubsegment();
-                        throw e;
+                        throw;
                     }
                 }
                 catch (ArgumentNullException e)


### PR DESCRIPTION
*Description of changes:*

Resolve CA2200 by rethrowing exception to preserve stack details
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2200

Note: this only affected a unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
