### PR TITLE
Improvement on signing step of release workflow + uncomment push to nuget.org step

### DIFF
--- a/.github/workflows/build-pack-release.yml
+++ b/.github/workflows/build-pack-release.yml
@@ -62,6 +62,7 @@ jobs:
           env:
             UNSIGNED_BUCKET: ${{ secrets.AWS_UNSIGNED_BUCKET_NAME }}
             SIGNED_BUCKET: ${{ secrets.AWS_SIGNED_BUCKET_NAME }}
+          #TODO: There is probably a better way to pass in a list of paths as a single parameter to the script.
           run: |
             .\buildtools\sign_files.ps1 -Filters AWSXRayRecorder.*.dll -Recurse -Path .\sdk\src\Core\bin\Release
             .\buildtools\sign_files.ps1 -Filters AWSXRayRecorder.*.dll -Recurse -Path .\sdk\src\Handlers\AspNet\bin\Release

--- a/.github/workflows/build-pack-release.yml
+++ b/.github/workflows/build-pack-release.yml
@@ -96,13 +96,19 @@ jobs:
             role-to-assume: ${{ secrets.NUGET_ACCESS_ROLE_ARN }}
             aws-region: us-west-2
 
-        # TODO: uncomment this step once the rest of the workflow has been verified in prod.
-        #- name: Push packages to Nuget.org
-        #  run: |
-        #    $nugetKey = aws secretsmanager get-secret-value --secret-id ${{ secrets.NUGET_SECRETS_ID }} --region us-west-2 --output text --query SecretString
-        #    nuget push .\Deployment\nuget-packages\*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey $nugetKey
+        - name: Push packages to Nuget.org
+          run: >
+            $nugetKey = aws secretsmanager get-secret-value
+            --secret-id ${{ secrets.NUGET_SECRETS_ID }}
+            --region us-west-2
+            --output text
+            --query SecretString
+
+            nuget push
+            .\Deployment\nuget-packages\*.nupkg
+            -Source https://api.nuget.org/v3/index.json
+            -ApiKey $nugetKey
             
-        # TODO: Change this step to directly create a public release once the workflow has been verified.
         - name: Create draft release
           id: create_release
           uses: actions/create-release@v1

--- a/.github/workflows/build-pack-release.yml
+++ b/.github/workflows/build-pack-release.yml
@@ -62,12 +62,15 @@ jobs:
           env:
             UNSIGNED_BUCKET: ${{ secrets.AWS_UNSIGNED_BUCKET_NAME }}
             SIGNED_BUCKET: ${{ secrets.AWS_SIGNED_BUCKET_NAME }}
-          run: >
-            .\buildtools\sign_files.ps1
-            -Path .\sdk\src
-            -Filters AWSXRayRecorder.*.dll
-            -Recurse
-
+          run: |
+            .\buildtools\sign_files.ps1 -Filters AWSXRayRecorder.*.dll -Recurse -Path .\sdk\src\Core\bin\Release
+            .\buildtools\sign_files.ps1 -Filters AWSXRayRecorder.*.dll -Recurse -Path .\sdk\src\Handlers\AspNet\bin\Release
+            .\buildtools\sign_files.ps1 -Filters AWSXRayRecorder.*.dll -Recurse -Path .\sdk\src\Handlers\AspNetCore\bin\Release
+            .\buildtools\sign_files.ps1 -Filters AWSXRayRecorder.*.dll -Recurse -Path .\sdk\src\Handlers\AwsSdk\bin\Release
+            .\buildtools\sign_files.ps1 -Filters AWSXRayRecorder.*.dll -Recurse -Path .\sdk\src\Handlers\EntityFramework\bin\Release
+            .\buildtools\sign_files.ps1 -Filters AWSXRayRecorder.*.dll -Recurse -Path .\sdk\src\Handlers\SqlServer\bin\Release
+            .\buildtools\sign_files.ps1 -Filters AWSXRayRecorder.*.dll -Recurse -Path .\sdk\src\Handlers\System.Net\bin\Release
+            
         - name: Pack nugets
           run: >
             dotnet pack


### PR DESCRIPTION
*Description of changes:*
- Invoking the signing script separately for each project path. This avoids signing unnecessary files from `\obj\` folder as well, as seen in [this test run](https://github.com/aws/aws-xray-sdk-dotnet/runs/7139466034?check_suite_focus=true).
  We only need to sign `.dll` files from the '\bin\` path because that's what ultimately gets shipped. We don't need to spend signing resources on intermediary files.

- Uncomment the step to publish the packages to nuget.org

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
