### PR TITLE
add dependency groups in nuspec for netframework462 and net6

### DIFF
--- a/sdk/AWSXRayRecorder.nuspec
+++ b/sdk/AWSXRayRecorder.nuspec
@@ -22,6 +22,14 @@
         <dependency id="AWSXRayRecorder.Handlers.SqlServer" version="2.7.3" />
         <dependency id="AWSXRayRecorder.Handlers.System.Net" version="2.7.3" />
       </group>
+	  <group targetFramework=".NETFramework4.6.2">
+        <dependency id="AWSXRayRecorder.Core" version="2.10.1" />
+        <dependency id="AWSXRayRecorder.Handlers.AspNet" version="2.7.3" />
+        <dependency id="AWSXRayRecorder.Handlers.AwsSdk" version="2.8.3" />
+        <dependency id="AWSXRayRecorder.Handlers.EntityFramework" version="1.1.1" />
+        <dependency id="AWSXRayRecorder.Handlers.SqlServer" version="2.7.3" />
+        <dependency id="AWSXRayRecorder.Handlers.System.Net" version="2.7.3" />
+      </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="AWSXRayRecorder.Core" version="2.10.1" />
         <dependency id="AWSXRayRecorder.Handlers.AspNetCore" version="2.7.3" />
@@ -38,9 +46,20 @@
         <dependency id="AWSXRayRecorder.Handlers.SqlServer" version="2.7.3" />
         <dependency id="AWSXRayRecorder.Handlers.System.Net" version="2.7.3" />
       </group>
+	  <group targetFramework="net6.0">
+        <dependency id="AWSXRayRecorder.Core" version="2.10.1" />
+        <dependency id="AWSXRayRecorder.Handlers.AspNetCore" version="2.7.3" />
+        <dependency id="AWSXRayRecorder.Handlers.AwsSdk" version="2.8.3" />
+        <dependency id="AWSXRayRecorder.Handlers.EntityFramework" version="1.1.1" />
+        <dependency id="AWSXRayRecorder.Handlers.SqlServer" version="2.7.3" />
+        <dependency id="AWSXRayRecorder.Handlers.System.Net" version="2.7.3" />
+      </group>
     </dependencies>
     <frameworkReferences>
       <group targetFramework=".NETCoreApp3.1">
+        <frameworkReference name="Microsoft.AspNetCore.App" />
+      </group>
+	  <group targetFramework="net6.0">
         <frameworkReference name="Microsoft.AspNetCore.App" />
       </group>
     </frameworkReferences>


### PR DESCRIPTION
*Issue*
The support for .NetFramework 4.6.2 and .Net 6.0 were added to the SDK in the following PRs:
https://github.com/aws/aws-xray-sdk-dotnet/pull/248
https://github.com/aws/aws-xray-sdk-dotnet/pull/242

But we missed out on adding these frameworks in the AWSXRayRecorder.nuspec which is used to create the bundle package.

*Description of changes:*
Adding a dependency group each for target frameworks ".NetFramework4.6.2" and "net6.0". Unfortunately, the [nuget spec](https://docs.microsoft.com/en-us/nuget/reference/nuspec#dependency-groups) doesn't provide a way to group target frameworks for common set of dependencies. This results in quite a bit of redundancy in the file.

I tested creating the `AWSXRayRecoder.nupkg` by running the following command and validated the package using the nuget explorer.
- command:
```
.\nuget pack .\sdk\AWSXRayRecorder.nuspec -OutputDirectory .\Deployment\nuget-packages -Exclude **
```
- screenshot of nuget explorer:
![Screen Shot 2022-07-12 at 5 30 02 PM](https://user-images.githubusercontent.com/50466688/178657906-85397ada-029d-4e1e-aa65-561c0f7869bc.png)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
