### PR TITLE
Removing duplicate groups which were added by mistake

### DIFF
--- a/sdk/AWSXRayRecorder.nuspec
+++ b/sdk/AWSXRayRecorder.nuspec
@@ -22,21 +22,13 @@
         <dependency id="AWSXRayRecorder.Handlers.SqlServer" version="2.8.0" />
         <dependency id="AWSXRayRecorder.Handlers.System.Net" version="2.8.0" />
       </group>
-	  <group targetFramework=".NETFramework4.6.2">
+      <group targetFramework=".NETFramework4.6.2">
         <dependency id="AWSXRayRecorder.Core" version="2.11.0" />
         <dependency id="AWSXRayRecorder.Handlers.AspNet" version="2.8.0" />
         <dependency id="AWSXRayRecorder.Handlers.AwsSdk" version="2.9.0" />
         <dependency id="AWSXRayRecorder.Handlers.EntityFramework" version="1.2.0" />
         <dependency id="AWSXRayRecorder.Handlers.SqlServer" version="2.8.0" />
         <dependency id="AWSXRayRecorder.Handlers.System.Net" version="2.8.0" />
-      </group>
-	  <group targetFramework=".NETFramework4.6.2">
-        <dependency id="AWSXRayRecorder.Core" version="2.10.1" />
-        <dependency id="AWSXRayRecorder.Handlers.AspNet" version="2.7.3" />
-        <dependency id="AWSXRayRecorder.Handlers.AwsSdk" version="2.8.3" />
-        <dependency id="AWSXRayRecorder.Handlers.EntityFramework" version="1.1.1" />
-        <dependency id="AWSXRayRecorder.Handlers.SqlServer" version="2.7.3" />
-        <dependency id="AWSXRayRecorder.Handlers.System.Net" version="2.7.3" />
       </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="AWSXRayRecorder.Core" version="2.11.0" />
@@ -54,21 +46,13 @@
         <dependency id="AWSXRayRecorder.Handlers.SqlServer" version="2.8.0" />
         <dependency id="AWSXRayRecorder.Handlers.System.Net" version="2.8.0" />
       </group>
-	  <group targetFramework="net6.0">
+      <group targetFramework="net6.0">
         <dependency id="AWSXRayRecorder.Core" version="2.11.0" />
         <dependency id="AWSXRayRecorder.Handlers.AspNetCore" version="2.8.0" />
         <dependency id="AWSXRayRecorder.Handlers.AwsSdk" version="2.9.0" />
         <dependency id="AWSXRayRecorder.Handlers.EntityFramework" version="1.2.0" />
         <dependency id="AWSXRayRecorder.Handlers.SqlServer" version="2.8.0" />
         <dependency id="AWSXRayRecorder.Handlers.System.Net" version="2.8.0" />
-      </group>
-	  <group targetFramework="net6.0">
-        <dependency id="AWSXRayRecorder.Core" version="2.10.1" />
-        <dependency id="AWSXRayRecorder.Handlers.AspNetCore" version="2.7.3" />
-        <dependency id="AWSXRayRecorder.Handlers.AwsSdk" version="2.8.3" />
-        <dependency id="AWSXRayRecorder.Handlers.EntityFramework" version="1.1.1" />
-        <dependency id="AWSXRayRecorder.Handlers.SqlServer" version="2.7.3" />
-        <dependency id="AWSXRayRecorder.Handlers.System.Net" version="2.7.3" />
       </group>
     </dependencies>
     <frameworkReferences>


### PR DESCRIPTION
*Issue #, if available:*
While merging the [release PR](https://github.com/aws/aws-xray-sdk-dotnet/pull/258), the dependency groups in the `AWSXRayRecorder.nuspec` got duplicated and had conflicting dependencies which caused the `nuget pack` command to fail.

Duplicate code blocks: 
https://github.com/aws/aws-xray-sdk-dotnet/blob/master/sdk/AWSXRayRecorder.nuspec#L25-L40
https://github.com/aws/aws-xray-sdk-dotnet/blob/master/sdk/AWSXRayRecorder.nuspec#L57-L72

Error log:
```
Attempting to build package from 'AWSXRayRecorder.nuspec'.
'AWSXRayRecorder' already has a dependency defined for 'AWSXRayRecorder.Core'.
```

*Description of changes:*
Removing the duplicates. Tested by running the `nuget pack` command.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
