### PR TITLE
extract key from secrets

### DIFF
--- a/.github/workflows/build-pack-release.yml
+++ b/.github/workflows/build-pack-release.yml
@@ -103,12 +103,12 @@ jobs:
             --secret-id ${{ secrets.NUGET_SECRETS_ID }}
             --region us-west-2
             --output text
-            --query SecretString
+            --query SecretString | ConvertFrom-Json
 
             nuget push
             .\Deployment\nuget-packages\*.nupkg
             -Source https://api.nuget.org/v3/index.json
-            -ApiKey $nugetKey
+            -ApiKey $nugetKey.Key
             
         - name: Create draft release
           id: create_release


### PR DESCRIPTION
*Issue #, if available:*
If the secret in SecretsManager is stored in a key-value format, we need to extract the key from the `SecretString` result in the command.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
