### PR TITLE
Restore TraceableSqlCommand for NetCoreApp3.1 and Dotnet 6 Runtimes

### DIFF
--- a/sdk/src/Handlers/SqlServer/AWSXRayRecorder.Handlers.SqlServer.csproj
+++ b/sdk/src/Handlers/SqlServer/AWSXRayRecorder.Handlers.SqlServer.csproj
@@ -33,7 +33,7 @@
     <Compile Remove="TraceableSqlCommand.netframework.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net462'">
     <Compile Remove="TraceableSqlCommand.netstandard.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
Issue #261

Between changes to target netcoreapp3.1 and net6.0, the TraceableSqlCommand.cs for netstandard was no longer being compiled

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
