### PR TITLE
feat(HttpClient): Provide tracing handler to allow removal of query string in traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,18 @@ HttpWebRequest request = (HttpWebRequest) WebRequest.Create(URL); // enter desir
 request.GetResponseTraced();
 ```
 
+for query parameter stripped http requests in trace 
+
+```csharp
+using Amazon.XRay.Recorder.Handlers.System.Net;
+
+HttpWebRequest request = (HttpWebRequest) WebRequest.Create(URL); // enter desired url
+
+// Any other configuration to the request
+
+request.GetResponseTraced(true);
+```
+
 #### Asynchronous request
 
 An extension method `GetAsyncResponseTraced()` is provided to trace `GetResponseAsync()` in `System.Net.HttpWebRequest` class. If you want to trace the out-going HTTP request, call the `GetAsyncResponseTraced()` instead of `GetResponseAsync()`. The extension method will generate a trace subsegment, inject the trace header to the out-going HTTP request header and collect trace information. 
@@ -276,6 +288,18 @@ HttpWebRequest request = (HttpWebRequest) WebRequest.Create(URL); // enter desir
 request.GetAsyncResponseTraced();
 ```
 
+for query parameter stripped http requests in trace 
+
+```csharp
+using Amazon.XRay.Recorder.Handlers.System.Net;
+
+HttpWebRequest request = (HttpWebRequest) WebRequest.Create(URL); // enter desired url
+
+// Any other configuration to the request
+
+request.GetAsyncResponseTraced(true);
+```
+
 #### Using `System.Net.HttpClient`
 
 A handler derived from `DelegatingHandler` is provided to trace the `HttpMessageHandler.SendAsync` method
@@ -288,6 +312,20 @@ var httpClient = new HttpClient(new HttpClientXRayTracingHandler(new HttpClientH
 // Any other configuration to the client
 
 httpClient.GetAsync(URL);
+```
+
+If you want to santize the Http request tracing then define the Tracing Handler as - 
+
+```CSharp
+
+using Amazon.XRay.Recorder.Handlers.System.Net;
+
+var httpClient = new HttpClient(new HttpClientXRaySanitizedTracingHandler(new HttpClientHandler()));
+
+// Any other configuration to the client
+
+httpClient.GetAsync(URL);
+
 ```
 
 #### Using `System.Net.Http.HttpClientFactory` (.Net Core 2.1 and above)
@@ -307,6 +345,22 @@ services.AddHttpClient("foo")
         .ConfigurePrimaryHttpMessageHandler(() =>
         {
             return new HttpClientXRayTracingHandler(new HttpClientHandler());
+        });
+```
+
+And to get sanitized http requests in tracing 
+
+```csharp
+services.AddHttpClient<IFooClient, FooClient>()
+        .AddHttpMessageHandler<HttpClientXRaySanitizedTracingHandler>();
+```
+or
+
+```csharp
+services.AddHttpClient("foo")
+        .ConfigurePrimaryHttpMessageHandler(() =>
+        {
+            return new HttpClientXRaySanitizedTracingHandler(new HttpClientHandler());
         });
 ```
 

--- a/sdk/src/Handlers/System.Net/HttpClientXRaySanitizedTracingHandler.cs
+++ b/sdk/src/Handlers/System.Net/HttpClientXRaySanitizedTracingHandler.cs
@@ -1,0 +1,72 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="HttpClientTracingHandler.cs" company="Amazon.com">
+//      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+//      Licensed under the Apache License, Version 2.0 (the "License").
+//      You may not use this file except in compliance with the License.
+//      A copy of the License is located at
+//
+//      http://aws.amazon.com/apache2.0
+//
+//      or in the "license" file accompanying this file. This file is distributed
+//      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//      express or implied. See the License for the specific language governing
+//      permissions and limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.XRay.Recorder.Core;
+using Amazon.XRay.Recorder.Handlers.System.Net.Utils;
+
+namespace Amazon.XRay.Recorder.Handlers.System.Net
+{
+    /// <summary>
+    /// Wrapper around <see cref="HttpClientHandler"/> for AWS X-Ray tracing of HTTP requests that will strip query parameters when tracing
+    /// </summary>
+    public class HttpClientXRaySanitizedTracingHandler : DelegatingHandler
+    {
+        private bool _sanitizeHttpRequestTracing { get; set; } = true;
+
+        public HttpClientXRaySanitizedTracingHandler() : base()
+        {
+        }
+
+        public HttpClientXRaySanitizedTracingHandler(HttpMessageHandler innerHandler) : base(innerHandler)
+        {
+        }
+
+        /// <summary>
+        /// Wrapper of <see cref="HttpClientHandler.SendAsync"/> method.
+        /// It collects information from request and response. Also, a trace header will be injected 
+        /// into the HttpWebRequest to propagate the tracing to downstream web service. 
+        /// </summary>
+        /// <param name="request">An instance of <see cref="HttpResponseMessage"/></param>
+        /// <param name="cancellationToken">An instance of <see cref="CancellationToken"/></param>
+        /// <returns>A Task of <see cref="HttpResponseMessage"/> representing the asynchronous operation</returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestUtil.ProcessRequest(request, _sanitizeHttpRequestTracing);
+            
+            HttpResponseMessage response;
+            try
+            {
+                response = await base.SendAsync(request, cancellationToken);
+                RequestUtil.ProcessResponse(response);
+            }
+            catch (Exception ex)
+            {
+                AWSXRayRecorder.Instance.AddException(ex);
+                throw;
+            }
+            finally
+            {
+                AWSXRayRecorder.Instance.EndSubsegment();
+            }
+            return response;
+        }
+    }
+}

--- a/sdk/src/Handlers/System.Net/HttpWebRequestTracingExtension.cs
+++ b/sdk/src/Handlers/System.Net/HttpWebRequestTracingExtension.cs
@@ -34,12 +34,14 @@ namespace Amazon.XRay.Recorder.Handlers.System.Net
         /// It collects information from request and response. Also, a trace header will be injected 
         /// into the HttpWebRequest to propagate the tracing to downstream web service. This method is 
         /// used for synchronous requests.
+        /// Request query string can be omitted from the http tracing depending on sanitizeHttpRequestTracing flag. Defaults to false, thus tracing absolute Uri.
         /// </summary>
         /// <param name="request">An instance of <see cref="WebRequest"/> which the method extended to</param>
+        /// <param name="sanitizeHttpRequestTracing"> <see cref="Boolean"/> value.</param>
         /// <returns>A <see cref="WebResponse"/> that contains the response from the Internet resource.</returns>
-        public static WebResponse GetResponseTraced(this WebRequest request)
+        public static WebResponse GetResponseTraced(this WebRequest request, bool sanitizeHttpRequestTracing = false)
         {
-            RequestUtil.ProcessRequest(request);
+            RequestUtil.ProcessRequest(request, sanitizeHttpRequestTracing);
 
             try
             {
@@ -75,12 +77,14 @@ namespace Amazon.XRay.Recorder.Handlers.System.Net
         /// It collects information from request and response. Also, a trace header will be injected 
         /// into the HttpWebRequest to propagate the tracing to downstream web service. This method is
         /// used for asynchronous requests.
+        /// Request query string can be omitted from the http tracing depending on sanitizeHttpRequestTracing flag. Defaults to false, thus tracing absolute Uri.
         /// </summary>
         /// <param name="request">An instance of <see cref="WebRequest"/> which the method extended to</param>
+        /// <param name="sanitizeHttpRequestTracing"> <see cref="Boolean"/> value.</param>
         /// <returns>A task of <see cref="WebResponse"/> that contains the response from the Internet resource.</returns>
-        public static async Task<WebResponse> GetAsyncResponseTraced(this WebRequest request)
+        public static async Task<WebResponse> GetAsyncResponseTraced(this WebRequest request, bool sanitizeHttpRequestTracing = false)
         {
-            RequestUtil.ProcessRequest(request);
+            RequestUtil.ProcessRequest(request, sanitizeHttpRequestTracing);
 
             try
             {

--- a/sdk/test/UnitTests/SanitizedHttpClientXRayTracingHandlerTests.cs
+++ b/sdk/test/UnitTests/SanitizedHttpClientXRayTracingHandlerTests.cs
@@ -1,0 +1,130 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Amazon.XRay.Recorder.Core;
+using Amazon.XRay.Recorder.Core.Internal.Entities;
+using Amazon.XRay.Recorder.Core.Internal.Utils;
+using Amazon.XRay.Recorder.Handlers.System.Net;
+using Amazon.XRay.Recorder.UnitTests.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Amazon.XRay.Recorder.UnitTests
+{
+    [TestClass]
+    public class SanitizedHttpClientXRayTracingHandlerTests : TestBase
+    {
+        private const string URL = "https://httpbin.org/?ab=test&ad=test";
+
+        private const string URL404 = "https://httpbin.org/404";
+
+        private readonly HttpClient _httpClient;
+
+        private static AWSXRayRecorder _recorder;
+
+        public SanitizedHttpClientXRayTracingHandlerTests()
+        {
+            _httpClient = new HttpClient(new HttpClientXRaySanitizedTracingHandler(new HttpClientHandler()));
+        }
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _recorder = new AWSXRayRecorder();
+            AWSXRayRecorder.InitializeInstance(recorder: _recorder);
+        }
+
+        [TestCleanup]
+        public new void TestCleanup()
+        {
+            base.TestCleanup();
+            _recorder.Dispose();
+            _recorder = null;
+        }
+
+        [TestMethod]
+        public async Task TestSendAsync()
+        {
+            AWSXRayRecorder.Instance.BeginSegment("parent", TraceId);
+            var request = new HttpRequestMessage(HttpMethod.Get, URL);
+            using(await _httpClient.SendAsync(request)) {}
+
+            var segment = AWSXRayRecorder.Instance.TraceContext.GetEntity();
+            AWSXRayRecorder.Instance.EndSegment();
+
+            var traceHeader = request.Headers.GetValues(TraceHeader.HeaderKey).SingleOrDefault();
+            Assert.IsNotNull(traceHeader);
+
+            var requestInfo = segment.Subsegments[0].Http["request"] as Dictionary<string, object>;
+            Assert.AreEqual(URL.Split(new[] { '?' })[0], requestInfo["url"]);
+            Assert.AreEqual("GET", requestInfo["method"]);
+
+            var responseInfo = segment.Subsegments[0].Http["response"] as Dictionary<string, object>;
+            Assert.AreEqual(200, responseInfo["status"]);
+            Assert.IsNotNull(responseInfo["content_length"]);
+        }
+        
+        /// <summary>
+        /// Ensures that when tracing is disabled that HTTP requests can execute as normal.
+        /// See https://github.com/aws/aws-xray-sdk-dotnet/issues/57 for more information. 
+        /// </summary>
+        [TestMethod]
+        public async Task TestXrayDisabledSendAsync()
+        {
+            _recorder = new MockAWSXRayRecorder() { IsTracingDisabledValue = true };
+            AWSXRayRecorder.InitializeInstance(recorder: _recorder);
+            Assert.IsTrue(AWSXRayRecorder.Instance.IsTracingDisabled());
+            
+            var request = new HttpRequestMessage(HttpMethod.Get, URL);
+            using (var response = await _httpClient.SendAsync(request))
+            {
+                Assert.IsNotNull(response);
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+
+        [TestMethod]
+        public async Task Test404SendAsync()
+        {
+            AWSXRayRecorder.Instance.BeginSegment("parent", TraceId);
+            var request = new HttpRequestMessage(HttpMethod.Get, URL404);
+            using(await _httpClient.SendAsync(request)) {}
+
+            var segment = AWSXRayRecorder.Instance.TraceContext.GetEntity();
+            AWSXRayRecorder.Instance.EndSegment();
+
+            var traceHeader = request.Headers.GetValues(TraceHeader.HeaderKey).SingleOrDefault();
+            Assert.IsNotNull(traceHeader);
+
+            var requestInfo = segment.Subsegments[0].Http["request"] as Dictionary<string, object>;
+            Assert.AreEqual(URL404, requestInfo["url"]);
+            Assert.AreEqual("GET", requestInfo["method"]);
+
+            var responseInfo = segment.Subsegments[0].Http["response"] as Dictionary<string, object>;
+            Assert.AreEqual(404, responseInfo["status"]);
+        }
+
+        [TestMethod]
+        public async Task TestXrayContextMissingStrategySendAsync() // Test that respects ContextMissingStrategy
+        {
+            _recorder = new MockAWSXRayRecorder();
+            AWSXRayRecorder.InitializeInstance(recorder: _recorder);
+            AWSXRayRecorder.Instance.ContextMissingStrategy = Core.Strategies.ContextMissingStrategy.LOG_ERROR;
+
+            Assert.IsFalse(AWSXRayRecorder.Instance.IsTracingDisabled());
+
+            _recorder.EndSegment();
+
+            // The test should not break. No segment is available in the context, however, since the context missing strategy is log error,
+            // no exception should be thrown by below code.
+
+            var request = new HttpRequestMessage(HttpMethod.Get, URL);
+            using (var response = await _httpClient.SendAsync(request))
+            {
+                Assert.IsNotNull(response);
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR resolves #201 

*Issue #, if available:*

*Description of changes:*

Added a new Tracing handler that will configure the httpmessagehandler in a way that when it adds traces to XRay recorder it will strip the query parameters around it and on trace the path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
