### PR TITLE
Fix issue #267 using version 3.7.100 of AWS SDK causing exception not finding EndpointResolver

### DIFF
--- a/sdk/src/Handlers/AwsSdk/AWSXRayRecorder.Handlers.AwsSdk.csproj
+++ b/sdk/src/Handlers/AwsSdk/AWSXRayRecorder.Handlers.AwsSdk.csproj
@@ -5,9 +5,9 @@
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
-    <AssemblyVersion>2.9.1.0</AssemblyVersion>
-    <FileVersion>2.9.1.0</FileVersion>
-    <Version>2.9.1</Version>
+    <AssemblyVersion>2.9.2.0</AssemblyVersion>
+    <FileVersion>2.9.2.0</FileVersion>
+    <Version>2.9.2</Version>
     <RootNamespace>Amazon.XRay.Recorder.Handlers.AwsSdk</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../../../buildtools/local-development.snk</AssemblyOriginatorKeyFile>

--- a/sdk/src/Handlers/AwsSdk/Internal/XRayPipelineHandler.cs
+++ b/sdk/src/Handlers/AwsSdk/Internal/XRayPipelineHandler.cs
@@ -745,11 +745,11 @@ namespace Amazon.XRay.Recorder.Handlers.AwsSdk.Internal
 
             if (addCustomization && AWSServiceHandlerManifest == null)
             {
-                pipeline.AddHandlerAfter<EndpointResolver>(new XRayPipelineHandler());
+                pipeline.AddHandlerBefore<RetryHandler>(new XRayPipelineHandler());
             }
             else if (addCustomization && AWSServiceHandlerManifest != null)
             {
-                pipeline.AddHandlerAfter<EndpointResolver>(new XRayPipelineHandler(AWSServiceHandlerManifest)); // Custom AWS Manifest file path/stream provided
+                pipeline.AddHandlerBefore<RetryHandler>(new XRayPipelineHandler(AWSServiceHandlerManifest)); // Custom AWS Manifest file path/stream provided
             }
         }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-sdk-dotnet/issues/267

*Description of changes:*
Starting with version 3.7.100 of the AWS .NET SDK the `EndpointResolver` is replaced with a service specific version of the handler. This breaks the X-Ray handler because X-Ray was inserting itself just after `EndpointResolver` in the SDK's request pipeline.

The fix is for X-Ray to inject itself before the `RetryHandler` which happens after endpoint resolutions. So the position will be the same in the request pipeline.

I have confirmed this fix works correctly by deploying a Lambda function and seeing the SDK traces in the console. I tested both with 3.7.100 and a version 3.7.10.1 to confirm we are not breaking users that haven't upgraded to the latest .NET SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
