### PR TITLE
Oversampling Mitigation

### DIFF
--- a/sdk/src/Core/AWSXRayRecorder.Core.csproj
+++ b/sdk/src/Core/AWSXRayRecorder.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net45;net462;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0;net462;net45</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>

--- a/sdk/src/Core/AWSXRayRecorder.Core.csproj
+++ b/sdk/src/Core/AWSXRayRecorder.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net462;netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net45;net462;netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>

--- a/sdk/src/Core/AWSXRayRecorder.Core.csproj
+++ b/sdk/src/Core/AWSXRayRecorder.Core.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net45' AND '$(TargetFramework)' != 'net462'">
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.1.0"/>
     <Compile Remove="Internal\Context\CallContextContainer.netframework.cs" />
     <Compile Remove="Internal\Context\HybridContextContainer.netframework.cs" />
     <Compile Remove="Internal\Utils\AppSettings.netframework.cs" />
@@ -57,6 +58,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net462'">
     <Compile Remove="Internal\Context\AsyncLocalContextContainer.netstandard.cs" />
     <Compile Remove="Internal\Context\LambdaContextContainer.netstandard.cs" />
+    <Compile Remove="Lambda\SQSMessageHelper.cs" />
     <Compile Remove="Internal\Utils\AppSettings.netcore.cs" />
     <Compile Remove="Internal\Utils\ConfigurationExtensions.cs" />
     <Compile Remove="AWSXRayRecorder.netcore.cs" />

--- a/sdk/src/Core/AWSXRayRecorder.netcore.cs
+++ b/sdk/src/Core/AWSXRayRecorder.netcore.cs
@@ -356,7 +356,7 @@ namespace Amazon.XRay.Recorder.Core
             }
 
             // Check emittable
-            if (subsegment.Sampled == SampleDecision.Sampled && subsegment.IsEmittable())
+            if (subsegment.IsEmittable())
             {
                 // Emit
                 Emitter.Send(subsegment.RootSegment);

--- a/sdk/src/Core/AWSXRayRecorder.netcore.cs
+++ b/sdk/src/Core/AWSXRayRecorder.netcore.cs
@@ -356,7 +356,7 @@ namespace Amazon.XRay.Recorder.Core
             }
 
             // Check emittable
-            if (subsegment.IsEmittable())
+            if (subsegment.Sampled == SampleDecision.Sampled && subsegment.IsEmittable())
             {
                 // Emit
                 Emitter.Send(subsegment.RootSegment);
@@ -405,7 +405,7 @@ namespace Amazon.XRay.Recorder.Core
                 if (!IsTracingDisabled())
                 {
                     PrepEndSegment(facadeSegment);
-                    if (facadeSegment.Sampled == SampleDecision.Sampled && facadeSegment.RootSegment != null && facadeSegment.RootSegment.Size >= 0)
+                    if (facadeSegment.RootSegment != null && facadeSegment.RootSegment.Size >= 0)
                     {
                         StreamingStrategy.Stream(facadeSegment, Emitter); //Facade segment is not emitted, all its subsegments, if emmittable, are emitted
                     }

--- a/sdk/src/Core/AWSXRayRecorderImpl.cs
+++ b/sdk/src/Core/AWSXRayRecorderImpl.cs
@@ -241,6 +241,16 @@ namespace Amazon.XRay.Recorder.Core
         public abstract void BeginSubsegment(string name, DateTime? timestamp = null);
 
         /// <summary>
+        /// Begin a tracing subsegment. A new segment will be created and added as a subsegment to previous segment.
+        /// </summary>
+        /// <param name="name">Name of the operation.</param>
+        public void BeginSubsegmentWithoutSampling(string name)
+        {
+            BeginSubsegment(name, null);
+            TraceContext.GetEntity().Sampled = SampleDecision.NotSampled;
+        }
+
+        /// <summary>
         /// End a subsegment.
         /// </summary>
         /// <param name="timestamp">Sets the end time for the subsegment</param>
@@ -802,7 +812,7 @@ namespace Amazon.XRay.Recorder.Core
             }
 
             // Check emittable
-            if (subsegment.IsEmittable())
+            if (subsegment.Sampled == SampleDecision.Sampled && subsegment.IsEmittable())
             {
                 // Emit
                 Emitter.Send(subsegment.RootSegment);

--- a/sdk/src/Core/AWSXRayRecorderImpl.cs
+++ b/sdk/src/Core/AWSXRayRecorderImpl.cs
@@ -232,7 +232,7 @@ namespace Amazon.XRay.Recorder.Core
         }
 
         /// <summary>
-        /// Begin a tracing subsegment. A new segment will be created and added as a subsegment to previous segment.
+        /// Begin a tracing subsegment. A new subsegment will be created and added as a subsegment to previous segment.
         /// </summary>
         /// <param name="name">Name of the operation.</param>
         /// <param name="timestamp">Sets the start time of the subsegment</param>
@@ -241,12 +241,12 @@ namespace Amazon.XRay.Recorder.Core
         public abstract void BeginSubsegment(string name, DateTime? timestamp = null);
 
         /// <summary>
-        /// Begin a tracing subsegment. A new segment will be created and added as a subsegment to previous segment.
+        /// Begin a tracing subsegment. A new subsegment will be created and added as a subsegment to previous segment.
         /// </summary>
         /// <param name="name">Name of the operation.</param>
         public void BeginSubsegmentWithoutSampling(string name)
         {
-            BeginSubsegment(name, null);
+            BeginSubsegment(name);
             TraceContext.GetEntity().Sampled = SampleDecision.NotSampled;
         }
 

--- a/sdk/src/Core/AWSXRayRecorderImpl.cs
+++ b/sdk/src/Core/AWSXRayRecorderImpl.cs
@@ -812,7 +812,7 @@ namespace Amazon.XRay.Recorder.Core
             }
 
             // Check emittable
-            if (subsegment.Sampled == SampleDecision.Sampled && subsegment.IsEmittable())
+            if (subsegment.IsEmittable())
             {
                 // Emit
                 Emitter.Send(subsegment.RootSegment);

--- a/sdk/src/Core/IAWSXRayRecorder.cs
+++ b/sdk/src/Core/IAWSXRayRecorder.cs
@@ -89,17 +89,17 @@ namespace Amazon.XRay.Recorder.Core
         void EndSegment(DateTime? timestamp = null);
 
         /// <summary>
-        /// Start a subsegment with a given segment
+        /// Start a subsegment with a given name and optional creation timestamp
         /// </summary>
-        /// <param name="name">Name of the operation</param>
+        /// <param name="name">Name of the subsegment</param>
         /// <param name="timestamp">Sets the start time for the subsegment</param>
         void BeginSubsegment(string name, DateTime? timestamp = null);
 
         /// <summary>
-        /// Start a subsegment with a given segment
+        /// Start a subsegment with a given name
         /// This subsegment will not emit and its trace context will have Sampled=0
         /// </summary>
-        /// <param name="name">Name of the operation</param>
+        /// <param name="name">Name of the subsegment</param>
         void BeginSubsegmentWithoutSampling(string name);
 
         /// <summary>

--- a/sdk/src/Core/IAWSXRayRecorder.cs
+++ b/sdk/src/Core/IAWSXRayRecorder.cs
@@ -96,6 +96,13 @@ namespace Amazon.XRay.Recorder.Core
         void BeginSubsegment(string name, DateTime? timestamp = null);
 
         /// <summary>
+        /// Start a subsegment with a given segment
+        /// This subsegment will not emit and its trace context will have Sampled=0
+        /// </summary>
+        /// <param name="name">Name of the operation</param>
+        void BeginSubsegmentWithoutSampling(string name);
+
+        /// <summary>
         /// End a subsegment
         /// </summary>
         /// <param name="timestamp">Sets the end time for the subsegment</param>

--- a/sdk/src/Core/Lambda/SQSMessageHelper.cs
+++ b/sdk/src/Core/Lambda/SQSMessageHelper.cs
@@ -1,0 +1,42 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="EC2Plugin.cs" company="Amazon.com">
+//      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+//      Licensed under the Apache License, Version 2.0 (the "License").
+//      You may not use this file except in compliance with the License.
+//      A copy of the License is located at
+//
+//      http://aws.amazon.com/apache2.0
+//
+//      or in the "license" file accompanying this file. This file is distributed
+//      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//      express or implied. See the License for the specific language governing
+//      permissions and limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using Amazon.Lambda.SQSEvents;
+using Amazon.Runtime.Internal.Util;
+using ThirdParty.LitJson;
+
+namespace Amazon.XRay.Recorder.Core.Lambda
+{
+    public class SQSMessageHelper
+    {
+        public static bool IsSampled(SQSEvent.SQSMessage message)
+        {
+            if (!message.Attributes.ContainsKey("AWSTraceHeader"))
+            {
+                return false;
+            }
+
+            return message.Attributes["AWSTraceHeader"].Contains("Sampled=1");
+        }
+    }
+}

--- a/sdk/src/Core/Lambda/SQSMessageHelper.cs
+++ b/sdk/src/Core/Lambda/SQSMessageHelper.cs
@@ -15,15 +15,7 @@
 // </copyright>
 //-----------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using System.Net.Http;
-using System.Text;
 using Amazon.Lambda.SQSEvents;
-using Amazon.Runtime.Internal.Util;
-using ThirdParty.LitJson;
 
 namespace Amazon.XRay.Recorder.Core.Lambda
 {

--- a/sdk/src/Core/Strategies/DefaultStreamingStrategy.cs
+++ b/sdk/src/Core/Strategies/DefaultStreamingStrategy.cs
@@ -68,7 +68,7 @@ namespace Amazon.XRay.Recorder.Core.Strategies
                 entity.Subsegments.RemoveAll(x => x.HasStreamed);
             }
 
-            if (entity is Segment || entity.IsInProgress || entity.Reference > 0 || entity.IsSubsegmentsAdded)
+            if (entity.Sampled != SampleDecision.Sampled || entity is Segment || entity.IsInProgress || entity.Reference > 0 || entity.IsSubsegmentsAdded)
             {
                 return;
             }

--- a/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
+++ b/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net452;net462;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0;net462;net452</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -20,7 +20,7 @@
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.0.26" />
     <PackageReference Include="Moq" Version="4.7.137" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0">
     </PackageReference>
 

--- a/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
+++ b/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   
   <PropertyGroup>
-    <TargetFrameworks>net452;net462;netcoreapp2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net452;net462;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>

--- a/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
+++ b/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0;net462;net452</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;netcoreapp2.0;net462;net452</TargetFrameworks>
     <Company>Amazon.com, Inc</Company>
     <Product>Amazon Web Service X-Ray Recorder</Product>
     <Copyright>Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -20,7 +20,7 @@
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.0.26" />
     <PackageReference Include="Moq" Version="4.7.137" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0">
     </PackageReference>
 

--- a/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
+++ b/sdk/test/UnitTests/AWSXRayRecorder.UnitTests.csproj
@@ -58,7 +58,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net452' AND '$(TargetFramework)' != 'net462'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.1.0"/>
     <Compile Remove="TestAppSettings.cs" />
     <Compile Remove="Tools\MockHttpRequest.cs" />
     <Compile Remove="Tools\MockHttpRequestFactory.cs" />
@@ -75,6 +75,7 @@
     <Compile Remove="Tools\TestEFContext.cs" />
     <Compile Remove="TestXRayOptions.cs" />
     <Compile Remove="TestLambdaContext.cs" />
+    <Compile Remove="SQSMessageHelperTests.cs" />
     <Compile Remove="FacadeSegmentTest.cs" />
     <Compile Remove="Tools\TestEFContext.cs" />
     <Compile Remove="EfCoreTests.cs" />

--- a/sdk/test/UnitTests/SQSMessageHelperTests.cs
+++ b/sdk/test/UnitTests/SQSMessageHelperTests.cs
@@ -1,0 +1,55 @@
+//-----------------------------------------------------------------------------
+// <copyright file="AwsXrayRecorderTests.cs" company="Amazon.com">
+//      Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+//      Licensed under the Apache License, Version 2.0 (the "License").
+//      You may not use this file except in compliance with the License.
+//      A copy of the License is located at
+//
+//      http://aws.amazon.com/apache2.0
+//
+//      or in the "license" file accompanying this file. This file is distributed
+//      on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//      express or implied. See the License for the specific language governing
+//      permissions and limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------------
+
+using Amazon.Lambda.SQSEvents;
+using Amazon.XRay.Recorder.Core.Lambda;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Amazon.XRay.Recorder.UnitTests
+{
+    [TestClass]
+    public class SQSMessageHelperTests : TestBase
+    {
+        [TestMethod]
+        public void TestSyncCreateSegmentAndSubsegments()
+        {
+            TestTrue("Root=1-632BB806-bd862e3fe1be46a994272793;Sampled=1");
+            TestTrue("Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1");
+            TestTrue("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1");
+
+            TestFalse("Root=1-632BB806-bd862e3fe1be46a994272793;Sampled=0");
+            TestFalse("Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=0");
+            TestFalse("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=0");
+        }
+
+        public static void TestTrue(string traceHeader)
+        {
+            SQSEvent.SQSMessage sqsMessage = new SQSEvent.SQSMessage();
+            sqsMessage.Attributes = new System.Collections.Generic.Dictionary<string, string>();
+            sqsMessage.Attributes.Add("AWSTraceHeader", traceHeader);
+            Assert.IsTrue(SQSMessageHelper.IsSampled(sqsMessage));
+        }
+
+        public static void TestFalse(string traceHeader)
+        {
+            SQSEvent.SQSMessage sqsMessage = new SQSEvent.SQSMessage();
+            sqsMessage.Attributes = new System.Collections.Generic.Dictionary<string, string>();
+            sqsMessage.Attributes.Add("AWSTraceHeader", traceHeader);
+            Assert.IsFalse (SQSMessageHelper.IsSampled(sqsMessage));
+        }
+    }
+}

--- a/sdk/test/UnitTests/TestLambdaContext.cs
+++ b/sdk/test/UnitTests/TestLambdaContext.cs
@@ -23,18 +23,16 @@ using Amazon.XRay.Recorder.Core.Sampling;
 using Amazon.XRay.Recorder.Core.Internal.Context;
 using Amazon.XRay.Recorder.Core.Internal.Utils;
 using System.Net;
-using System.Security.Policy;
 using Amazon.XRay.Recorder.Handlers.System.Net;
 using Moq;
 using Amazon.XRay.Recorder.Core.Internal.Emitters;
-using Amazon.XRay.Recorder.UnitTests.Tools;
 
 namespace Amazon.XRay.Recorder.UnitTests
 {
     [TestClass]
     public class TestLambdaContext : TestBase
     {
-        private const string URL = "https://httpbin.org/";
+        private const string MOCK_URL = "https://httpbin.org/";
         private static readonly String _traceHeaderValue = "Root=" + TraceId + ";Parent=53995c3f42cd8ad8;Sampled=1";
         private AWSXRayRecorder _recorder;
 
@@ -64,21 +62,21 @@ namespace Amazon.XRay.Recorder.UnitTests
             {
                 AWSXRayRecorder.InitializeInstance(recorder: _recorder);
 
-                LambdaTestHelper(recorder, true);
+                TestLambdaHelper(recorder, true);
                 mockEmitter.Verify(x => x.Send(It.IsAny<Subsegment>()), Times.Exactly(2));
 
-                LambdaTestHelper(recorder, false);
+                TestLambdaHelper(recorder, false);
                 mockEmitter.Verify(x => x.Send(It.IsAny<Subsegment>()), Times.Exactly(2));
 
-                LambdaTestHelper(recorder, true);
+                TestLambdaHelper(recorder, true);
                 mockEmitter.Verify(x => x.Send(It.IsAny<Subsegment>()), Times.Exactly(4));
 
-                LambdaTestHelper(recorder, false);
+                TestLambdaHelper(recorder, false);
                 mockEmitter.Verify(x => x.Send(It.IsAny<Subsegment>()), Times.Exactly(4));
             }
         }
 
-        private static void LambdaTestHelper(AWSXRayRecorder recorder, bool sampled)
+        private static void TestLambdaHelper(AWSXRayRecorder recorder, bool sampled)
         {
             if (sampled)
             {
@@ -89,7 +87,7 @@ namespace Amazon.XRay.Recorder.UnitTests
                 recorder.BeginSubsegmentWithoutSampling("subsegment1");
             }
 
-            var request = (HttpWebRequest)WebRequest.Create(URL);
+            var request = (HttpWebRequest)WebRequest.Create(MOCK_URL);
 
             using (var response = request.GetResponseTraced() as HttpWebResponse)
             {

--- a/sdk/test/UnitTests/TestLambdaContext.cs
+++ b/sdk/test/UnitTests/TestLambdaContext.cs
@@ -78,7 +78,7 @@ namespace Amazon.XRay.Recorder.UnitTests
             }
         }
 
-        private void LambdaTestHelper(AWSXRayRecorder recorder, bool sampled)
+        private static void LambdaTestHelper(AWSXRayRecorder recorder, bool sampled)
         {
             if (sampled)
             {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding Oversampling Mitigation.
SQSMessageHelper's IsSampled function returns true only if the SQSMessage passed in is sampled.
BeginSubsegmentWithoutSampling was added to AWSXrayReccorder which allows the creating of subsegments that ignore the parent entity's sampled flag and never emit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
