### PR TITLE
install .net sdks for smoke tests

### DIFF
--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -27,13 +27,12 @@ jobs:
                aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                aws-region: us-east-1
 
-          - uses: actions/setup-dotnet@v1
+          - name: Setup dotnet
+            uses: actions/setup-dotnet@v1
             with:
-              dotnet-version: '3.1.x'
-
-          - uses: actions/setup-dotnet@v1
-            with:
-              dotnet-version: '6.0.x'
+              dotnet-version: |
+                3.1.x
+                6.0.x
 
           - name: Install dependencies
             run: dotnet restore sdk/test/SmokeTests/AWSXRayRecorder.SmokeTests.csproj

--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -27,6 +27,14 @@ jobs:
                aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                aws-region: us-east-1
 
+          - uses: actions/setup-dotnet@v1
+            with:
+              dotnet-version: '3.1.x'
+
+          - uses: actions/setup-dotnet@v1
+            with:
+              dotnet-version: '6.0.x'
+
           - name: Install dependencies
             run: dotnet restore sdk/test/SmokeTests/AWSXRayRecorder.SmokeTests.csproj
 


### PR DESCRIPTION
The continuous monitoring CI has been failing due to the `ubuntu-latest` image dropping the .Net 3.1.0 SDK.
To avoid this in the future, we can explicitly install the .Net SDKs required for the smoke tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
