### PR TITLE
ec2plugin: fallback to utf8 if response encoding not set

### DIFF
--- a/sdk/src/Core/Plugins/EC2Plugin.cs
+++ b/sdk/src/Core/Plugins/EC2Plugin.cs
@@ -142,7 +142,9 @@ namespace Amazon.XRay.Recorder.Core.Plugins
                     throw new Exception("Unable to complete the request successfully");
                 }
 
-                var encoding = Encoding.GetEncoding(response.ContentEncoding);
+                var encoding = !string.IsNullOrEmpty(response.ContentEncoding)
+                    ? Encoding.GetEncoding(response.ContentEncoding)
+                    : Encoding.UTF8;
 
                 using (var streamReader = new StreamReader(response.GetResponseStream(), encoding))
                 {


### PR DESCRIPTION
*Issue #, if available:* #277

*Description of changes:*

If `repsonse.ContentEncoding` is not set then this will fallback to UTF8 to prevent an exception.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
