### PR TITLE
Change context missing strategy behaviour to Log Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -666,7 +666,7 @@ All notable changes to this project will be documented in this file.
 ### AWSXRayRecorder.Core (1.0.2-beta)
 #### Added
 - Runtime information to the `aws.xray` namespace on segments.
-- Added a `ContextMissingStrategy` property to the `IAWSXRayRecorder` interface. This allows configuration of the exception behavior exhibited when trace context is not properly propagated. The behavior can be configured in code. Alternatively, the environment variable `AWS_XRAY_CONTEXT_MISSING` can be used (overrides any modes set in code). Valid values for this environment variable are currently (case insensitive) `RUNTIME_ERROR` and `LOG_ERROR`. By default, an exception will be thrown on missing context.
+- Added a `ContextMissingStrategy` property to the `IAWSXRayRecorder` interface. This allows configuration of the exception behavior exhibited when trace context is not properly propagated. The behavior can be configured in code. Alternatively, the environment variable `AWS_XRAY_CONTEXT_MISSING` can be used (overrides any modes set in code). Valid values for this environment variable are currently (case insensitive) `RUNTIME_ERROR` and `LOG_ERROR`. By default, errors are logged on missing context.
 
 #### Changed
 - Renamed `SegmentNotAvailableException` to `EntityNotAvailableException`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -666,7 +666,7 @@ All notable changes to this project will be documented in this file.
 ### AWSXRayRecorder.Core (1.0.2-beta)
 #### Added
 - Runtime information to the `aws.xray` namespace on segments.
-- Added a `ContextMissingStrategy` property to the `IAWSXRayRecorder` interface. This allows configuration of the exception behavior exhibited when trace context is not properly propagated. The behavior can be configured in code. Alternatively, the environment variable `AWS_XRAY_CONTEXT_MISSING` can be used (overrides any modes set in code). Valid values for this environment variable are currently (case insensitive) `RUNTIME_ERROR` and `LOG_ERROR`. By default, errors are logged on missing context.
+- Added a `ContextMissingStrategy` property to the `IAWSXRayRecorder` interface. This allows configuration of the exception behavior exhibited when trace context is not properly propagated. The behavior can be configured in code. Alternatively, the environment variable `AWS_XRAY_CONTEXT_MISSING` can be used (overrides any modes set in code). Valid values for this environment variable are currently (case insensitive) `RUNTIME_ERROR` and `LOG_ERROR`. By default, an exception will be thrown on missing context.
 
 #### Changed
 - Renamed `SegmentNotAvailableException` to `EntityNotAvailableException`

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can configure X-Ray in the `appsettings` of your `App.config` or `Web.config
     <add key="AWSXRayPlugins" value="EC2Plugin, ECSPlugin, ElasticBeanstalkPlugin"/>
     <add key="SamplingRuleManifest" value="JSONs\DefaultSamplingRules.json"/>
     <add key="AwsServiceHandlerManifest" value="JSONs\AWSRequestInfo.json"/>
-    <add key="UseRuntimeErrors" value="true"/>
+    <add key="UseRuntimeErrors" value="false"/>
     <add key="CollectSqlQueries" value="false"/>
   </appSettings>
 </configuration>
@@ -91,7 +91,7 @@ a) In `appsettings.json` file, configure items under `XRay` key
     "SamplingRuleManifest": "SamplingRules.json",
     "AWSXRayPlugins": "EC2Plugin, ECSPlugin, ElasticBeanstalkPlugin",
     "AwsServiceHandlerManifest": "JSONs\AWSRequestInfo.json",
-    "UseRuntimeErrors":"true",
+    "UseRuntimeErrors":"false",
     "CollectSqlQueries":"false"
   }
 }

--- a/sdk/src/Core/AWSXRayRecorderImpl.cs
+++ b/sdk/src/Core/AWSXRayRecorderImpl.cs
@@ -61,7 +61,7 @@ namespace Amazon.XRay.Recorder.Core
 
         private ISegmentEmitter _emitter;
         private bool disposed;
-        protected ContextMissingStrategy cntxtMissingStrategy = ContextMissingStrategy.RUNTIME_ERROR;
+        protected ContextMissingStrategy cntxtMissingStrategy = ContextMissingStrategy.LOG_ERROR;
         private Dictionary<string, object> serviceContext = new Dictionary<string, object>();
 
         protected AWSXRayRecorderImpl(ISegmentEmitter emitter)

--- a/sdk/src/Core/AwsXrayRecorderBuilder.cs
+++ b/sdk/src/Core/AwsXrayRecorderBuilder.cs
@@ -38,7 +38,7 @@ namespace Amazon.XRay.Recorder.Core
 
         private readonly List<IPlugin> _plugins = new List<IPlugin>();
         private ISamplingStrategy _samplingStrategy;
-        private ContextMissingStrategy _contextMissingStrategy = ContextMissingStrategy.RUNTIME_ERROR;
+        private ContextMissingStrategy _contextMissingStrategy = ContextMissingStrategy.LOG_ERROR;
         private ISegmentEmitter _segmentEmitter;
         private string _daemonAddress;
         private ITraceContext _traceContext;
@@ -89,7 +89,7 @@ namespace Amazon.XRay.Recorder.Core
 
         /// <summary>
         /// Reads useRuntimeErrors settings from app settings, and adds into the builder.
-        /// If the useRuntimeErrors settings doesn't exist, it defaults to true and ContextMissingStrategy.RUNTIME_ERROR is used.
+        /// If the useRuntimeErrors settings doesn't exist, it defaults to false and ContextMissingStrategy.LOG_ERROR is used.
         /// </summary>
         /// <returns>The builder with context missing strategy set.</returns>
         public AWSXRayRecorderBuilder WithContextMissingStrategyFromAppSettings()
@@ -123,7 +123,7 @@ namespace Amazon.XRay.Recorder.Core
 
         /// <summary>
         /// Reads useRuntimeErrors settings from config instance, and adds into the builder.
-        /// If the useRuntimeErrors settings doesn't exist, it defaults to true and ContextMissingStrategy.RUNTIME_ERROR is used.
+        /// If the useRuntimeErrors settings doesn't exist, it defaults to false and ContextMissingStrategy.LOG_ERROR is used.
         /// </summary>
         /// <returns>The builder with context missing strategy set.</returns>
         public AWSXRayRecorderBuilder WithContextMissingStrategyFromConfig(XRayOptions xRayOptions)

--- a/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
+++ b/sdk/src/Core/Internal/Utils/AppSettings.netcore.cs
@@ -88,7 +88,7 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
         /// <summary>
         /// For missing Segments/Subsegments, if set to true, runtime exception is thrown, if set to false, runtime exceptions are avoided and logged.
         /// </summary>
-        public bool UseRuntimeErrors { get; set; } = true;
+        public bool UseRuntimeErrors { get; set; } = false;
 
         /// <summary>
         /// Include the TraceableSqlCommand.CommandText in the sanitized_query section of 

--- a/sdk/src/Core/Internal/Utils/AppSettings.netframework.cs
+++ b/sdk/src/Core/Internal/Utils/AppSettings.netframework.cs
@@ -131,8 +131,8 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
             return defaultValue;
         }
 
-        // If the key not present, default value set to true.
-        private static bool GetSettingBoolForRuntimeError(string key, bool defaultValue = true)
+        // If the key not present, default value set to false.
+        private static bool GetSettingBoolForRuntimeError(string key, bool defaultValue = false)
         {
             string value = GetSetting(key);
             if (bool.TryParse(value, out bool result))

--- a/sdk/src/Core/Internal/Utils/ConfigurationExtensions.cs
+++ b/sdk/src/Core/Internal/Utils/ConfigurationExtensions.cs
@@ -64,7 +64,7 @@ namespace Amazon.XRay.Recorder.Core.Internal.Utils
             options.SamplingRuleManifest = GetSetting(SamplingRuleManifestKey, section);
             options.AwsServiceHandlerManifest =GetSetting(AWSServiceHandlerManifestKey, section);
             options.IsXRayTracingDisabled = GetSettingBool(DisableXRayTracingKey,section);
-            options.UseRuntimeErrors = GetSettingBool(UseRuntimeErrorsKey, section, defaultValue: true);
+            options.UseRuntimeErrors = GetSettingBool(UseRuntimeErrorsKey, section, defaultValue: false);
             options.CollectSqlQueries = GetSettingBool(CollectSqlQueries, section, defaultValue: false);
             return options;
         }

--- a/sdk/src/Core/Strategies/ContextMissingStrategy.cs
+++ b/sdk/src/Core/Strategies/ContextMissingStrategy.cs
@@ -25,11 +25,11 @@ namespace Amazon.XRay.Recorder.Core.Strategies
         /// <summary>
         /// The EntityNotAvailableException will be thrown if occurs at runtime.
         /// </summary>
-        RUNTIME_ERROR = 0,  // Set to 0, so it is default value
+        RUNTIME_ERROR = 1,
 
         /// <summary>
         /// The EntityNotAvailableException will be logged if occurs.
         /// </summary>
-        LOG_ERROR = 1, 
+        LOG_ERROR = 0,  // Set to 0, so it is default value
     }
 }

--- a/sdk/test/UnitTests/AWSXRayRecorderBuilderTests.cs
+++ b/sdk/test/UnitTests/AWSXRayRecorderBuilderTests.cs
@@ -149,7 +149,7 @@ namespace Amazon.XRay.Recorder.UnitTests
         public void TestDefaultValueOfContextMissingStrategy()
         {
             var recorder = new AWSXRayRecorderBuilder().Build();
-            Assert.AreEqual(ContextMissingStrategy.RUNTIME_ERROR, recorder.ContextMissingStrategy);
+            Assert.AreEqual(ContextMissingStrategy.LOG_ERROR, recorder.ContextMissingStrategy);
         }
 
         [TestMethod]
@@ -175,7 +175,7 @@ namespace Amazon.XRay.Recorder.UnitTests
         }
 
         [TestMethod]
-        public void TestSetContextMissingUsingConfiguration2() // Contextmissing startegy not set
+        public void TestSetContextMissingUsingConfiguration2() // Contextmissing strategy not set
         {
 #if NETFRAMEWORK
             AppSettings.Reset();
@@ -184,7 +184,7 @@ namespace Amazon.XRay.Recorder.UnitTests
             AWSXRayRecorderBuilder builder = new AWSXRayRecorderBuilder().WithContextMissingStrategyFromConfig(_xRayOptions);
 #endif
             AWSXRayRecorder recorder = builder.Build();
-            Assert.AreEqual(ContextMissingStrategy.RUNTIME_ERROR, recorder.ContextMissingStrategy); // Default context missing strategy is set
+            Assert.AreEqual(ContextMissingStrategy.LOG_ERROR, recorder.ContextMissingStrategy); // Default context missing strategy is set
         }
 
         [TestMethod]

--- a/sdk/test/UnitTests/TestAppSettings.cs
+++ b/sdk/test/UnitTests/TestAppSettings.cs
@@ -95,16 +95,16 @@ namespace Amazon.XRay.Recorder.UnitTests
             ConfigurationManager.AppSettings[UseRuntimeErrors] = "invalid";
             AppSettings.Reset();
             var recorder = GetRecorder();
-            Assert.AreEqual(Core.Strategies.ContextMissingStrategy.RUNTIME_ERROR ,recorder.ContextMissingStrategy);
+            Assert.AreEqual(Core.Strategies.ContextMissingStrategy.LOG_ERROR ,recorder.ContextMissingStrategy);
         }
 
 
         [TestMethod]
-        public void TestUseRuntimeErrorsNoKeyPresent()
+        public void TestUseLogErrorsNoKeyPresent()
         {
             AppSettings.Reset();
             var recorder = GetRecorder();
-            Assert.AreEqual(Core.Strategies.ContextMissingStrategy.RUNTIME_ERROR, recorder.ContextMissingStrategy);
+            Assert.AreEqual(Core.Strategies.ContextMissingStrategy.LOG_ERROR, recorder.ContextMissingStrategy);
         }
 
         [TestMethod]

--- a/sdk/test/UnitTests/TestXRayOptions.cs
+++ b/sdk/test/UnitTests/TestXRayOptions.cs
@@ -127,7 +127,7 @@ namespace Amazon.XRay.Recorder.UnitTests
             Assert.IsNull(_xRayOptions.AwsServiceHandlerManifest);
             Assert.IsNull(_xRayOptions.PluginSetting);
             Assert.IsNull(_xRayOptions.SamplingRuleManifest);
-            Assert.IsTrue(_xRayOptions.UseRuntimeErrors);
+            Assert.IsFalse(_xRayOptions.UseRuntimeErrors);
 
             Assert.AreEqual(typeof(UdpSegmentEmitter), AWSXRayRecorder.Instance.Emitter.GetType()); // Default emitter set
 
@@ -147,7 +147,7 @@ namespace Amazon.XRay.Recorder.UnitTests
             Assert.IsNull(_xRayOptions.AwsServiceHandlerManifest);
             Assert.IsNull(_xRayOptions.PluginSetting);
             Assert.IsNull(_xRayOptions.SamplingRuleManifest);
-            Assert.IsTrue(_xRayOptions.UseRuntimeErrors);
+            Assert.IsFalse(_xRayOptions.UseRuntimeErrors);
 
             Assert.AreEqual(AWSXRayRecorder.Instance.SamplingStrategy, recorder.SamplingStrategy); // Custom recorder set in TraceContext
             Assert.AreEqual(typeof(UdpSegmentEmitter), recorder.Emitter.GetType()); // Default emitter set
@@ -167,7 +167,7 @@ namespace Amazon.XRay.Recorder.UnitTests
             Assert.IsNull(_xRayOptions.AwsServiceHandlerManifest);
             Assert.IsNull(_xRayOptions.PluginSetting);
             Assert.IsNull(_xRayOptions.SamplingRuleManifest);
-            Assert.IsTrue(_xRayOptions.UseRuntimeErrors);
+            Assert.IsFalse(_xRayOptions.UseRuntimeErrors);
 
             Assert.AreEqual(AWSXRayRecorder.Instance.SamplingStrategy, recorder.SamplingStrategy); // Custom recorder set in TraceContext
             Assert.AreEqual(typeof(DummyEmitter), recorder.Emitter.GetType()); // custom emitter set
@@ -201,7 +201,7 @@ namespace Amazon.XRay.Recorder.UnitTests
         }
 
         [TestMethod]
-        public void TestUseRuntimeErrorsDefaultsTrue_WhenNotSpecifiedInJson()
+        public void TestUseLogErrorsDefaultsTrue_WhenNotSpecifiedInJson()
         {
             IConfiguration configuration = TestXRayOptions.BuildConfiguration("DisabledXRayMissing.json");
 
@@ -209,8 +209,8 @@ namespace Amazon.XRay.Recorder.UnitTests
 
             AWSXRayRecorder.InitializeInstance(configuration);
 
-            Assert.IsTrue(_xRayOptions.UseRuntimeErrors);
-            Assert.AreEqual(AWSXRayRecorder.Instance.ContextMissingStrategy, Core.Strategies.ContextMissingStrategy.RUNTIME_ERROR);
+            Assert.IsFalse(_xRayOptions.UseRuntimeErrors);
+            Assert.AreEqual(AWSXRayRecorder.Instance.ContextMissingStrategy, Core.Strategies.ContextMissingStrategy.LOG_ERROR);
         }
 
         [TestMethod]

--- a/sdk/test/UnitTests/TestXRayOptions.cs
+++ b/sdk/test/UnitTests/TestXRayOptions.cs
@@ -201,7 +201,7 @@ namespace Amazon.XRay.Recorder.UnitTests
         }
 
         [TestMethod]
-        public void TestUseLogErrorsDefaultsTrue_WhenNotSpecifiedInJson()
+        public void TestUseRuntimeErrorsDefaultsFalse_WhenNotSpecifiedInJson()
         {
             IConfiguration configuration = TestXRayOptions.BuildConfiguration("DisabledXRayMissing.json");
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change sets the default context missing strategy to 'LOG_ERROR' instead of 'RUNTIME_ERROR' to mitigate malformed trace headers from breaking services.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
