### PR TITLE
Update System.Data.SqlClient version for CVE mitigation

### DIFF
--- a/sdk/src/Handlers/SqlServer/AWSXRayRecorder.Handlers.SqlServer.csproj
+++ b/sdk/src/Handlers/SqlServer/AWSXRayRecorder.Handlers.SqlServer.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
 </Project>

--- a/sdk/test/UnitTests/HttpClientXRayTracingHandlerTests.cs
+++ b/sdk/test/UnitTests/HttpClientXRayTracingHandlerTests.cs
@@ -17,7 +17,7 @@ namespace Amazon.XRay.Recorder.UnitTests
     {
         private const string URL = "https://httpbin.org/";
 
-        private const string URL404 = "https://httpbin.org/404";
+        private const string URL404 = "https://httpbin.org/status/404";
 
         private readonly HttpClient _httpClient;
 

--- a/sdk/test/UnitTests/HttpWebRequestTracingExtensionTests.cs
+++ b/sdk/test/UnitTests/HttpWebRequestTracingExtensionTests.cs
@@ -33,7 +33,7 @@ namespace Amazon.XRay.Recorder.UnitTests
     {
         private const string URL = "https://httpbin.org/";
 
-        private const string URL404 = "https://httpbin.org/404";
+        private const string URL404 = "https://httpbin.org/status/404";
 
         private static AWSXRayRecorder _recorder;
 

--- a/sdk/test/UnitTests/SanitizedHttpClientXRayTracingHandlerTests.cs
+++ b/sdk/test/UnitTests/SanitizedHttpClientXRayTracingHandlerTests.cs
@@ -17,7 +17,7 @@ namespace Amazon.XRay.Recorder.UnitTests
     {
         private const string URL = "https://httpbin.org/?ab=test&ad=test";
 
-        private const string URL404 = "https://httpbin.org/404";
+        private const string URL404 = "https://httpbin.org/status/404";
 
         private readonly HttpClient _httpClient;
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-xray-sdk-dotnet/issues/293

*Description of changes:*
- Updated the `System.Data.SqlClient` version from 4.4.0 to 4.8.6
- Fixed the `httpbin.org` URL in the tests to use the `https://httpbin.org/status/{status_code}` as per the websites schema: https://httpbin.org/#/Status_codes/get_status__codes_



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
