### PR TITLE
trim quotes from jobId in signing script

### DIFF
--- a/buildtools/sign_files.ps1
+++ b/buildtools/sign_files.ps1
@@ -86,6 +86,7 @@ Begin
         $retryCount = 0        
         do {
             $jobId = aws s3api get-object-tagging --bucket $unsignedS3bucket --key $key --version-id $versionId --query 'TagSet[?Key==`signer-job-id`].Value | [0]'
+            $jobId = $jobId.Trim('"')
             $retryCount++
         } while ($jobId -eq "null" -and $retryCount -le $maxRetryCount)
 


### PR DESCRIPTION
*Issue:* 
- Since our last release somehow [this line in the signing script](https://github.com/aws/aws-xray-sdk-dotnet/blob/f143e3b18af56928743acc910b90c60bd52bbf0e/buildtools/sign_files.ps1#L88) started returning the `$jobId` with quotation marks. It is still unknown why this started to happen.
  - Tested this out by printing the object key ([test run](https://github.com/aws/aws-xray-sdk-dotnet/actions/runs/9589126897/job/26442396839)). Notice that the key has quotes around the jobId suffix: `Fetching object from signed bucket:  AWSXRayRecorder.Core.dll-"96430257-ff4b-4f6e-b57c-3322c8c1da1c"` 
  - Since the objects in the signed buckets don't have `"` in their keys (confirmed by looking at the S3 bucket), `get-object` returns "AccessDenied".
- Fix is to simply remove the `"` from jobId.
  - Tested this out here and the workflow (without actual publish steps) worked fine: https://github.com/aws/aws-xray-sdk-dotnet/actions/runs/9602151884/job/26482347355

*Description of changes:*
- Using powershell's [`Trim()`](https://devblogs.microsoft.com/scripting/trim-your-strings-with-powershell/) to remove `"` from `$jobId`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
