### PR TITLE
Add locking mechanism for Subsegments in Entity.AddException method

### DIFF
--- a/sdk/src/Core/Internal/Entities/Entity.cs
+++ b/sdk/src/Core/Internal/Entities/Entity.cs
@@ -514,7 +514,13 @@ namespace Amazon.XRay.Recorder.Core.Internal.Entities
         {
             HasFault = true;
             Cause = new Cause();
-            Cause.AddException(AWSXRayRecorder.Instance.ExceptionSerializationStrategy.DescribeException(e, Subsegments));
+            List<Subsegment> subsegmentsCopy;
+            lock (_lazySubsegments.Value)
+            {
+                subsegmentsCopy = _lazySubsegments.Value.ToList(); // Create a copy to avoid holding the lock during serialization
+            }
+
+            Cause.AddException(AWSXRayRecorder.Instance.ExceptionSerializationStrategy.DescribeException(e, subsegmentsCopy));
         }
 
         /// <summary>


### PR DESCRIPTION
*Issue #306:*

*Description of changes:*
Implement a locking mechanism for Subsegments in `Entity.AddException` method to ensure thread safety and prevent race conditions during exception handling.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
