### PR TITLE
Downgrade Ubuntu Version to 20.04 to avoid broken netcore3.1 support

### DIFF
--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -4,6 +4,9 @@ on:
     workflow_dispatch:
     schedule:
       - cron: '*/10 * * * *'
+    push:
+      branches:
+        -"distro-action-fix"
 
 permissions:
   id-token: write
@@ -13,6 +16,9 @@ jobs:
     smoke-tests:
         name: Run smoke tests
         runs-on: ${{ matrix.os }}
+        
+        env:
+          DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
         
         strategy:
             fail-fast: false

--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -23,7 +23,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest]
+                os: [ubuntu-20.04]
                 version: [netcoreapp3.1, net6.0]
 
         steps:

--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -30,11 +30,11 @@ jobs:
           - name: Checkout repository
             uses: actions/checkout@v2
             
-          - name: Configure AWS Credentials
-            uses: aws-actions/configure-aws-credentials@v4
-            with:
-               role-to-assume: ${{ secrets.AWS_INTEG_TEST_ROLE_ARN }}
-               aws-region: us-east-1
+          # - name: Configure AWS Credentials
+          #   uses: aws-actions/configure-aws-credentials@v4
+          #   with:
+          #      role-to-assume: ${{ secrets.AWS_INTEG_TEST_ROLE_ARN }}
+          #      aws-region: us-east-1
 
           - name: Setup dotnet
             uses: actions/setup-dotnet@v1

--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -43,6 +43,9 @@ jobs:
                 3.1.x
                 6.0.x
 
+          - name: Install System Dependencies
+            run: sudo apt-get update && sudo apt-get install -y libssl-dev libicu-dev
+
           - name: Install dependencies
             run: dotnet restore sdk/test/SmokeTests/AWSXRayRecorder.SmokeTests.csproj
 

--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -4,9 +4,6 @@ on:
     workflow_dispatch:
     schedule:
       - cron: '*/10 * * * *'
-    push:
-      branches:
-        - "distro-action-fix"
 
 permissions:
   id-token: write
@@ -16,9 +13,6 @@ jobs:
     smoke-tests:
         name: Run smoke tests
         runs-on: ${{ matrix.os }}
-
-        env:
-          DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
         
         strategy:
             fail-fast: false
@@ -30,11 +24,11 @@ jobs:
           - name: Checkout repository
             uses: actions/checkout@v2
             
-          # - name: Configure AWS Credentials
-          #   uses: aws-actions/configure-aws-credentials@v4
-          #   with:
-          #      role-to-assume: ${{ secrets.AWS_INTEG_TEST_ROLE_ARN }}
-          #      aws-region: us-east-1
+          - name: Configure AWS Credentials
+            uses: aws-actions/configure-aws-credentials@v4
+            with:
+               role-to-assume: ${{ secrets.AWS_INTEG_TEST_ROLE_ARN }}
+               aws-region: us-east-1
 
           - name: Setup dotnet
             uses: actions/setup-dotnet@v1
@@ -42,9 +36,6 @@ jobs:
               dotnet-version: |
                 3.1.x
                 6.0.x
-
-          - name: Install System Dependencies
-            run: sudo apt-get update && sudo apt-get install -y libssl-dev libicu-dev
 
           - name: Install dependencies
             run: dotnet restore sdk/test/SmokeTests/AWSXRayRecorder.SmokeTests.csproj
@@ -56,11 +47,11 @@ jobs:
             id: distribution-availability
             run: dotnet test sdk/test/SmokeTests/bin/Release/${{matrix.version}}/AWSXRayRecorder.SmokeTests.dll
             
-          # - name: Publish metric on X-Ray Dotnet SDK distribution availability
-          #   if: ${{ always() }}
-          #   run: |
-          #     if [[ "${{ steps.distribution-availability.outcome }}" == "failure" ]]; then
-          #       aws cloudwatch put-metric-data --metric-name XRayDotnetSDKDistributionUnavailability --dimensions failure=rate --namespace MonitorSDK --value 1 --timestamp $(date +%s)
-          #     else
-          #       aws cloudwatch put-metric-data --metric-name XRayDotnetSDKDistributionUnavailability --dimensions failure=rate --namespace MonitorSDK --value 0 --timestamp $(date +%s)
-          #     fi
+          - name: Publish metric on X-Ray Dotnet SDK distribution availability
+            if: ${{ always() }}
+            run: |
+              if [[ "${{ steps.distribution-availability.outcome }}" == "failure" ]]; then
+                aws cloudwatch put-metric-data --metric-name XRayDotnetSDKDistributionUnavailability --dimensions failure=rate --namespace MonitorSDK --value 1 --timestamp $(date +%s)
+              else
+                aws cloudwatch put-metric-data --metric-name XRayDotnetSDKDistributionUnavailability --dimensions failure=rate --namespace MonitorSDK --value 0 --timestamp $(date +%s)
+              fi

--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -6,7 +6,7 @@ on:
       - cron: '*/10 * * * *'
     push:
       branches:
-        -"distro-action-fix"
+        - "distro-action-fix"
 
 permissions:
   id-token: write
@@ -16,7 +16,7 @@ jobs:
     smoke-tests:
         name: Run smoke tests
         runs-on: ${{ matrix.os }}
-        
+
         env:
           DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
         
@@ -53,11 +53,11 @@ jobs:
             id: distribution-availability
             run: dotnet test sdk/test/SmokeTests/bin/Release/${{matrix.version}}/AWSXRayRecorder.SmokeTests.dll
             
-          - name: Publish metric on X-Ray Dotnet SDK distribution availability
-            if: ${{ always() }}
-            run: |
-              if [[ "${{ steps.distribution-availability.outcome }}" == "failure" ]]; then
-                aws cloudwatch put-metric-data --metric-name XRayDotnetSDKDistributionUnavailability --dimensions failure=rate --namespace MonitorSDK --value 1 --timestamp $(date +%s)
-              else
-                aws cloudwatch put-metric-data --metric-name XRayDotnetSDKDistributionUnavailability --dimensions failure=rate --namespace MonitorSDK --value 0 --timestamp $(date +%s)
-              fi
+          # - name: Publish metric on X-Ray Dotnet SDK distribution availability
+          #   if: ${{ always() }}
+          #   run: |
+          #     if [[ "${{ steps.distribution-availability.outcome }}" == "failure" ]]; then
+          #       aws cloudwatch put-metric-data --metric-name XRayDotnetSDKDistributionUnavailability --dimensions failure=rate --namespace MonitorSDK --value 1 --timestamp $(date +%s)
+          #     else
+          #       aws cloudwatch put-metric-data --metric-name XRayDotnetSDKDistributionUnavailability --dimensions failure=rate --namespace MonitorSDK --value 0 --timestamp $(date +%s)
+          #     fi


### PR DESCRIPTION
*Issue #, if available:*
Recent updated ubuntu-latest vesion only support openssl 3.0, broken the support for .netcore3.1, which only support openssl 1.1 and 1.0
*Description of changes:*
Downgrade to Ubuntu20.04 to ensure continue support for netcore3.1

*Test:*
https://github.com/aws/aws-xray-sdk-dotnet/actions/runs/12835534449/job/35795166272

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
