### PR TITLE
fix(daily-scan): point Trivy at published artifact dependencies

### DIFF
--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -1,7 +1,7 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: Apache-2.0
 # Performs a daily scan of:
-# * The latest released X-Ray .NET SDK artifacts, using Trivy
+# * The published artifact dependencies, using Trivy
 # * Project dependencies, using DependencyCheck
 #
 #  Publishes results to CloudWatch Metrics.
@@ -81,29 +81,27 @@ jobs:
         if: ${{ steps.dep_scan.outcome != 'success' }}
         run: less dependency-check-report.html
 
-      - name: Build .NET solution for scanning
+      - name: Build scan target for Trivy
         if: always()
-        run: |
-          dotnet restore sdk/AWSXRayRecorder.sln
-          dotnet build sdk/AWSXRayRecorder.sln --configuration Release --no-restore
+        run: dotnet build scan-target/ --configuration Release --no-restore
 
-      - name: Perform high severity scan on built artifacts
+      - name: Perform high severity scan on published artifact dependencies
         if: always()
         id: high_scan_latest
         uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.2
         with:
           scan-type: 'fs'
-          scan-ref: 'sdk/src/Core/bin/Release/'
+          scan-ref: 'scan-target/'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
 
-      - name: Perform low severity scan on built artifacts
+      - name: Perform low severity scan on published artifact dependencies
         if: always()
         id: low_scan_latest
         uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.2
         with:
           scan-type: 'fs'
-          scan-ref: 'sdk/src/Core/bin/Release/'
+          scan-ref: 'scan-target/'
           severity: 'MEDIUM,LOW,UNKNOWN'
           exit-code: '1'
 

--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -62,6 +62,12 @@ jobs:
           dotnet new console -o scan-target --no-restore --force --framework net8.0
           cd scan-target
           dotnet add package AWSXRayRecorder.Core
+          dotnet add package AWSXRayRecorder.Handlers.AwsSdk
+          dotnet add package AWSXRayRecorder.Handlers.AspNetCore
+          dotnet add package AWSXRayRecorder.Handlers.AspNet
+          dotnet add package AWSXRayRecorder.Handlers.EntityFramework
+          dotnet add package AWSXRayRecorder.Handlers.SqlServer
+          dotnet add package AWSXRayRecorder.Handlers.System.Net
           dotnet restore --packages ./packages
 
       # See http://jeremylong.github.io/DependencyCheck/dependency-check-cli/ for installation explanation


### PR DESCRIPTION
## What
Point Trivy at the published artifact dependency tree (`scan-target/`) and expand DependencyCheck to cover all 7 published NuGet packages (was only scanning Core).

## Why
1. **Trivy misaligned**: Trivy was scanning `scan-ref: 'sdk/src/Core/bin/Release/'` — build output from the full SDK solution at HEAD, which included test project dependencies and scanned HEAD instead of the released version.
2. **Incomplete DC coverage**: DC was only scanning `AWSXRayRecorder.Core`. The repo publishes 7 NuGet packages (Core, Handlers.AwsSdk, Handlers.AspNetCore, Handlers.AspNet, Handlers.EntityFramework, Handlers.SqlServer, Handlers.System.Net) each with their own dependency trees.

## How
- Added all 7 published NuGet packages to the install step
- Replaced the build step: instead of building the full SDK solution (which includes test projects), we now build the console app in `scan-target/` to generate the `.deps.json` file Trivy needs
- Changed Trivy `scan-ref` from `'sdk/src/Core/bin/Release/'` to `'scan-target/'`

## Local validation
- **DC**: 201 deps found (up from 137), 19 with vulns, 0 false positives, 0 DC tool jars
- **Trivy**: Parses `.deps.json`, 0 vulns currently